### PR TITLE
Add image upload, fix absolute path bug, improve IP detection, expand…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Features
 - **VM lifecycle management** — create, start, stop, delete VMs with a single command
 - **Cloud-init support** — inject SSH keys and configuration at boot
 - **Snapshots** — capture and restore VM state at any point
-- **Portable images** — export VMs to standalone qcow2 images and distribute via SCP or HTTP
+- **Portable images** — upload, export, download, and distribute qcow2 images via the GUI or SCP/HTTP
 - **NAT networking with port forwarding** — expose VM services to the local network
 - **REST API** — run as a daemon for programmatic access
 - **Web GUI** — React dashboard embedded in the binary, served alongside the API
@@ -54,19 +54,28 @@ make build
 make build-go
 ```
 
-### 4. Download a base image
+### 4. Get a base image
 
+**Option A — download directly:**
 ```bash
-# Example: Ubuntu 22.04 cloud image
 wget -O /var/lib/vmsmith/images/ubuntu-22.04.qcow2 \
   https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+```
+
+**Option B — upload via the web GUI:**
+
+Open `http://localhost:8080`, go to **Images → Upload Image**, drag-and-drop a `.qcow2` file.
+
+**Option C — provide an absolute path when creating a VM:**
+```bash
+vmsmith vm create my-server --image /path/to/ubuntu-22.04.qcow2 ...
 ```
 
 ### 5. Create and manage VMs
 
 ```bash
-# Create a VM
-vmsmith vm create my-server --image ubuntu-22.04.qcow2 --cpus 2 --ram 2048 --disk 20 \
+# Create a VM (image name registered in the image store, or absolute path)
+vmsmith vm create my-server --image ubuntu-22.04 --cpus 2 --ram 2048 --disk 20 \
   --ssh-key "$(cat ~/.ssh/id_rsa.pub)"
 
 # List VMs
@@ -143,7 +152,7 @@ make test-web
 make test-all
 ```
 
-The test suite includes 83 tests across three tiers: unit tests for each package, API integration tests using a mock VM manager + httptest, and end-to-end headless browser tests using Playwright against a mock API server. See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#testing-strategy) for details.
+The test suite includes 151 tests across three tiers: unit tests for each package, API integration tests using a mock VM manager + httptest, and end-to-end headless browser tests using Playwright against a mock API server. See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#testing-strategy) for details.
 
 ## Troubleshooting
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -181,7 +181,7 @@ The MVP implements `LibvirtVMManager`. When KubeVirt support is added, a `KubeVi
 ### 1. VM Lifecycle
 
 **Creating a VM:**
-1. User provides: name, base image, CPU count, RAM, disk size, optional cloud-init data
+1. User provides: name, base image (registered name or absolute path), CPU count, RAM, disk size, optional cloud-init data
 2. VM Smith creates a qcow2 overlay disk backed by the base image (copy-on-write)
 3. Generates libvirt domain XML with the VM's specs
 4. Attaches the VM to the vmsmith NAT network
@@ -317,8 +317,10 @@ POST /api/v1/vms
 **Images** (portable, for distribution to other hosts):
 - Created by exporting a VM's disk to a standalone qcow2 file
 - `vmsmith image create myvm --name "ubuntu-base-configured"`
+- Or uploaded directly via the web GUI (Images → Upload Image, drag-and-drop `.qcow2`)
 - The image is a flattened qcow2 (no backing file dependencies)
-- Stored in `~/.vmsmith/images/` (or configured path)
+- Stored in the configured images directory (default `/var/lib/vmsmith/images/`)
+- Paths are shown in the Images page and can be used directly with `--image /abs/path`
 
 **Image Transfer:**
 - **Push:** `vmsmith image push ubuntu-base-configured user@remote-host`
@@ -357,10 +359,10 @@ All endpoints are prefixed with `/api/v1/`.
 | POST   | /vms/{id}/snapshots/{snapId}/restore    | Restore a snapshot           |
 | DELETE | /vms/{id}/snapshots/{snapId}            | Delete a snapshot            |
 | GET    | /images                                 | List images                  |
-| POST   | /images                                 | Create image from VM         |
+| POST   | /images                                 | Create image from VM disk    |
+| POST   | /images/upload                          | Upload a qcow2 image file    |
 | DELETE | /images/{id}                            | Delete an image              |
 | GET    | /images/{id}/download                   | Download image file          |
-| POST   | /images/upload                          | Upload an image              |
 | GET    | /vms/{id}/ports                         | List port forwards for a VM  |
 | POST   | /vms/{id}/ports                         | Add a port forward           |
 | DELETE | /vms/{id}/ports/{portId}                | Remove a port forward        |
@@ -518,7 +520,7 @@ internal/web/
 | `/`           | Dashboard  | Stats overview, VM list with quick actions          |
 | `/vms`        | VM List    | Create modal, start/stop/delete actions             |
 | `/vms/:id`    | VM Detail  | Info cards, snapshot management, port forwarding     |
-| `/images`     | Images     | List, download, delete portable disk images          |
+| `/images`     | Images     | Upload, list, download, delete portable disk images  |
 
 **Production build:** `make build` runs `npm run build` first (outputting to `internal/web/dist/`), then compiles the Go binary with the SPA embedded. The resulting binary serves the GUI on the same port as the API (default `:8080`).
 
@@ -597,10 +599,10 @@ make test-all
 |---------------|---------------------|-------|------------------------------------------------------|
 | Unit          | store               | 9     | CRUD for VMs, images, ports; persistence; networks   |
 | Unit          | config              | 5     | Defaults, file load, YAML merge, invalid YAML, dirs  |
-| Unit          | vm/domain           | 16    | XML gen, multi-net, macvtap/bridge, MAC, validation  |
+| Unit          | vm/domain           | 18    | XML gen, multi-net, macvtap/bridge/NAT, MAC, validation |
 | Unit          | vm/mock             | 8     | Mock lifecycle, snapshots, error injection, seeding  |
 | Unit          | cli                 | 12    | Network flag parsing, all options, errors, humanSize |
-| Unit          | storage             | 1     | findLastSlash helper                                 |
-| Integration   | api                 | 16    | All REST endpoints, error handling, full lifecycle   |
+| Unit          | storage             | 11    | ImportImage, ListImages, GetImage, DeleteImage, path |
+| Integration   | api                 | 28    | All REST endpoints including upload; error paths     |
 | E2E (browser) | web                 | 16    | Dashboard, VM CRUD, snapshots, images, navigation    |
-| **Total**     |                     | **83**|                                                      |
+| **Total**     |                     | **151**|                                                     |

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -856,6 +857,90 @@ func TestRemovePort_NotFound(t *testing.T) {
 		t.Errorf("status = %d, want 500 (port not found)", resp.StatusCode)
 	}
 }
+
+// ============================================================
+// Upload image handler tests
+// ============================================================
+
+func TestUploadImage_MissingFile(t *testing.T) {
+	ts, _, cleanup := testServer(t)
+	defer cleanup()
+
+	// multipart with no "file" field
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	mw.WriteField("name", "myimage")
+	mw.Close()
+
+	resp, err := http.Post(ts.URL+"/api/v1/images/upload", mw.FormDataContentType(), &buf)
+	if err != nil {
+		t.Fatalf("POST upload: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestUploadImage_Success(t *testing.T) {
+	ts, _, cleanup := testServer(t)
+	defer cleanup()
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile("file", "ubuntu-22.04.qcow2")
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	fw.Write([]byte("fake qcow2 content"))
+	mw.Close()
+
+	resp, err := http.Post(ts.URL+"/api/v1/images/upload", mw.FormDataContentType(), &buf)
+	if err != nil {
+		t.Fatalf("POST upload: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("status = %d, want 201", resp.StatusCode)
+	}
+
+	var img types.Image
+	decodeJSON(t, resp, &img)
+	if img.Name != "ubuntu-22.04" {
+		t.Errorf("Name = %q, want %q", img.Name, "ubuntu-22.04")
+	}
+	if img.ID == "" {
+		t.Error("ID should not be empty")
+	}
+}
+
+func TestUploadImage_CustomName(t *testing.T) {
+	ts, _, cleanup := testServer(t)
+	defer cleanup()
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, _ := mw.CreateFormFile("file", "some-file.qcow2")
+	fw.Write([]byte("data"))
+	mw.WriteField("name", "custom-name")
+	mw.Close()
+
+	resp, err := http.Post(ts.URL+"/api/v1/images/upload", mw.FormDataContentType(), &buf)
+	if err != nil {
+		t.Fatalf("POST upload: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("status = %d, want 201", resp.StatusCode)
+	}
+	var img types.Image
+	decodeJSON(t, resp, &img)
+	if img.Name != "custom-name" {
+		t.Errorf("Name = %q, want %q", img.Name, "custom-name")
+	}
+}
+
 
 // ============================================================
 // Content-Type regression tests (web handler vs API routes)

--- a/internal/api/handlers_image.go
+++ b/internal/api/handlers_image.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -54,6 +56,49 @@ func (s *Server) DeleteImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// UploadImage handles POST /api/v1/images/upload (multipart form: file + name)
+func (s *Server) UploadImage(w http.ResponseWriter, r *http.Request) {
+	// Limit upload to 50 GB
+	if err := r.ParseMultipartForm(50 << 30); err != nil {
+		writeError(w, http.StatusBadRequest, "failed to parse form: "+err.Error())
+		return
+	}
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "missing file field")
+		return
+	}
+	defer file.Close()
+
+	name := strings.TrimSpace(r.FormValue("name"))
+	if name == "" {
+		// Derive name from filename, strip extension
+		name = header.Filename
+		if i := strings.LastIndex(name, "."); i > 0 {
+			name = name[:i]
+		}
+	}
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "image name is required")
+		return
+	}
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "reading upload: "+err.Error())
+		return
+	}
+
+	img, err := s.storageMgr.ImportImage(name, data)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, img)
 }
 
 // DownloadImage handles GET /api/v1/images/{imageID}/download

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -75,6 +75,7 @@ func (s *Server) setupRoutes(webHandler http.Handler) {
 		r.Route("/images", func(r chi.Router) {
 			r.Get("/", s.ListImages)
 			r.Post("/", s.CreateImage)
+			r.Post("/upload", s.UploadImage)
 			r.Delete("/{imageID}", s.DeleteImage)
 			r.Get("/{imageID}/download", s.DownloadImage)
 		})

--- a/internal/cli/vm.go
+++ b/internal/cli/vm.go
@@ -201,7 +201,7 @@ var vmInfoCmd = &cobra.Command{
 }
 
 func init() {
-	vmCreateCmd.Flags().String("image", "", "base image name (required)")
+	vmCreateCmd.Flags().String("image", "", "base image name or absolute path to a .qcow2 file (required)")
 	vmCreateCmd.Flags().Int("cpus", 0, "number of vCPUs (default from config)")
 	vmCreateCmd.Flags().Int("ram", 0, "RAM in MB (default from config)")
 	vmCreateCmd.Flags().Int("disk", 0, "disk size in GB (default from config)")

--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -87,3 +87,31 @@ func (m *Manager) GetImage(id string) (*types.Image, error) {
 func (m *Manager) ImagePath(name string) string {
 	return filepath.Join(m.cfg.Storage.ImagesDir, name+".qcow2")
 }
+
+// ImportImage saves an uploaded file into the images directory and registers it.
+func (m *Manager) ImportImage(name string, src []byte) (*types.Image, error) {
+	if err := os.MkdirAll(m.cfg.Storage.ImagesDir, 0o755); err != nil {
+		return nil, err
+	}
+
+	imagePath := filepath.Join(m.cfg.Storage.ImagesDir, name+".qcow2")
+	if err := os.WriteFile(imagePath, src, 0o644); err != nil {
+		return nil, fmt.Errorf("writing image file: %w", err)
+	}
+
+	img := &types.Image{
+		ID:        fmt.Sprintf("img-%d", time.Now().UnixNano()),
+		Name:      name,
+		Path:      imagePath,
+		SizeBytes: int64(len(src)),
+		Format:    "qcow2",
+		CreatedAt: time.Now(),
+	}
+
+	if err := m.store.PutImage(img); err != nil {
+		os.Remove(imagePath)
+		return nil, err
+	}
+
+	return img, nil
+}

--- a/internal/storage/image_test.go
+++ b/internal/storage/image_test.go
@@ -141,3 +141,54 @@ func TestStorageManager_ImagePath(t *testing.T) {
 		t.Errorf("ImagePath = %q, want %q", got, want)
 	}
 }
+
+func TestStorageManager_ImportImage_Success(t *testing.T) {
+	mgr, _, imagesDir := newTestManager(t)
+
+	content := []byte("fake qcow2 data")
+	img, err := mgr.ImportImage("uploaded-image", content)
+	if err != nil {
+		t.Fatalf("ImportImage: %v", err)
+	}
+
+	if img.Name != "uploaded-image" {
+		t.Errorf("Name = %q, want uploaded-image", img.Name)
+	}
+	if img.ID == "" {
+		t.Error("ID should not be empty")
+	}
+	expectedPath := filepath.Join(imagesDir, "uploaded-image.qcow2")
+	if img.Path != expectedPath {
+		t.Errorf("Path = %q, want %q", img.Path, expectedPath)
+	}
+	if img.SizeBytes != int64(len(content)) {
+		t.Errorf("SizeBytes = %d, want %d", img.SizeBytes, len(content))
+	}
+	if img.Format != "qcow2" {
+		t.Errorf("Format = %q, want qcow2", img.Format)
+	}
+
+	// File should exist on disk.
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Errorf("file not on disk: %v", err)
+	}
+}
+
+func TestStorageManager_ImportImage_Persisted(t *testing.T) {
+	mgr, _, _ := newTestManager(t)
+
+	if _, err := mgr.ImportImage("persist-test", []byte("data")); err != nil {
+		t.Fatalf("ImportImage: %v", err)
+	}
+
+	imgs, err := mgr.ListImages()
+	if err != nil {
+		t.Fatalf("ListImages: %v", err)
+	}
+	if len(imgs) != 1 {
+		t.Fatalf("expected 1 image in store, got %d", len(imgs))
+	}
+	if imgs[0].Name != "persist-test" {
+		t.Errorf("Name = %q, want persist-test", imgs[0].Name)
+	}
+}

--- a/internal/vm/domain_test.go
+++ b/internal/vm/domain_test.go
@@ -259,6 +259,50 @@ func TestValidateNetworkAttachments_Empty(t *testing.T) {
 	}
 }
 
+func TestDomainParamsFromSpec_NATAttachment(t *testing.T) {
+	spec := types.VMSpec{
+		Name: "nat-vm",
+		Networks: []types.NetworkAttachment{
+			{Mode: types.NetworkModeNAT, MacAddress: "52:54:00:aa:bb:cc"},
+		},
+	}
+
+	params := DomainParamsFromSpec(spec, "/tmp/d.qcow2", "", "vmsmith-net")
+
+	// Should have 2 interfaces: default NAT + extra NAT attachment
+	if len(params.Interfaces) != 2 {
+		t.Fatalf("expected 2 interfaces, got %d", len(params.Interfaces))
+	}
+	if !strings.Contains(params.Interfaces[1].XML, "aa:bb:cc") {
+		t.Error("extra NAT interface should include specified MAC")
+	}
+}
+
+func TestGenerateDomainXML_MultipleInterfaces(t *testing.T) {
+	params := DomainParams{
+		Name:     "multi-vm",
+		CPUs:     2,
+		RAMMB:    2048,
+		DiskPath: "/tmp/disk.qcow2",
+		Interfaces: []InterfaceEntry{
+			{XML: `<interface type='network'><source network='vmsmith-net'/></interface>`},
+			{XML: `<interface type='direct'><source dev='eth1' mode='bridge'/></interface>`},
+		},
+	}
+
+	xml, err := GenerateDomainXML(params)
+	if err != nil {
+		t.Fatalf("GenerateDomainXML: %v", err)
+	}
+
+	if !strings.Contains(xml, "vmsmith-net") {
+		t.Error("should contain NAT network")
+	}
+	if !strings.Contains(xml, "eth1") {
+		t.Error("should contain macvtap interface")
+	}
+}
+
 // --- Cloud-init network config generation tests ---
 
 func TestGenerateNetworkConfig_StaticIP(t *testing.T) {

--- a/internal/vm/lifecycle.go
+++ b/internal/vm/lifecycle.go
@@ -90,7 +90,10 @@ func (m *LibvirtManager) Create(ctx context.Context, spec types.VMSpec) (*types.
 
 	// Create qcow2 overlay backed by the base image
 	diskPath := filepath.Join(vmDir, "disk.qcow2")
-	baseImage := filepath.Join(m.cfg.Storage.ImagesDir, spec.Image)
+	baseImage := spec.Image
+	if !filepath.IsAbs(spec.Image) {
+		baseImage = filepath.Join(m.cfg.Storage.ImagesDir, spec.Image)
+	}
 	if err := createOverlayDisk(baseImage, diskPath, spec.DiskGB); err != nil {
 		return nil, fmt.Errorf("creating overlay disk: %w", err)
 	}
@@ -492,15 +495,22 @@ func domainStateToVMState(dom *libvirt.Domain) types.VMState {
 }
 
 func getDomainIP(dom *libvirt.Domain) string {
-	// Try to get IP via DHCP leases on the libvirt network
-	ifaces, err := dom.ListAllInterfaceAddresses(libvirt.DOMAIN_INTERFACE_ADDRESSES_SRC_LEASE)
-	if err != nil || len(ifaces) == 0 {
-		return ""
+	// Try multiple sources in order of reliability.
+	sources := []libvirt.DomainInterfaceAddressesSource{
+		libvirt.DOMAIN_INTERFACE_ADDRESSES_SRC_AGENT, // QEMU guest agent (most accurate)
+		libvirt.DOMAIN_INTERFACE_ADDRESSES_SRC_LEASE, // libvirt dnsmasq leases
+		libvirt.DOMAIN_INTERFACE_ADDRESSES_SRC_ARP,   // host ARP cache
 	}
-	for _, iface := range ifaces {
-		for _, addr := range iface.Addrs {
-			if addr.Type == libvirt.IP_ADDR_TYPE_IPV4 {
-				return addr.Addr
+	for _, src := range sources {
+		ifaces, err := dom.ListAllInterfaceAddresses(src)
+		if err != nil {
+			continue
+		}
+		for _, iface := range ifaces {
+			for _, addr := range iface.Addrs {
+				if addr.Type == libvirt.IP_ADDR_TYPE_IPV4 {
+					return addr.Addr
+				}
 			}
 		}
 	}

--- a/web/src/api/client.js
+++ b/web/src/api/client.js
@@ -2,8 +2,9 @@ const BASE = '/api/v1';
 
 async function request(path, options = {}) {
   const url = `${BASE}${path}`;
+  const isFormData = options.body instanceof FormData;
   const res = await fetch(url, {
-    headers: { 'Content-Type': 'application/json', ...options.headers },
+    headers: isFormData ? options.headers : { 'Content-Type': 'application/json', ...options.headers },
     ...options,
   });
 
@@ -36,6 +37,12 @@ export const snapshots = {
 export const images = {
   list:     ()            => request('/images'),
   create:   (vmId, name)  => request('/images', { method: 'POST', body: JSON.stringify({ vm_id: vmId, name }) }),
+  upload:   (file, name)  => {
+    const fd = new FormData();
+    fd.append('file', file);
+    if (name) fd.append('name', name);
+    return request('/images/upload', { method: 'POST', body: fd });
+  },
   delete:   (id)          => request(`/images/${id}`, { method: 'DELETE' }),
   downloadUrl: (id)       => `${BASE}/images/${id}/download`,
 };

--- a/web/src/pages/ImageList.jsx
+++ b/web/src/pages/ImageList.jsx
@@ -1,9 +1,11 @@
-import { HardDrive, Download, Trash2 } from 'lucide-react';
+import { useState, useRef } from 'react';
+import { HardDrive, Download, Trash2, Upload } from 'lucide-react';
 import { images as imagesApi } from '../api/client';
 import { useFetch, useMutation } from '../hooks/useFetch';
-import { PageHeader, EmptyState, Spinner, ErrorBanner } from '../components/Shared';
+import { PageHeader, EmptyState, Spinner, ErrorBanner, Modal } from '../components/Shared';
 
 export default function ImageList() {
+  const [showUpload, setShowUpload] = useState(false);
   const { data: imageList, loading, error, refresh } = useFetch(() => imagesApi.list(), [], 10000);
   const deleteMut = useMutation(imagesApi.delete);
 
@@ -24,9 +26,16 @@ export default function ImageList() {
       <PageHeader
         title="Images"
         subtitle="Portable VM disk images"
+        actions={
+          <button className="btn-primary" onClick={() => setShowUpload(true)}>
+            <Upload size={15} /> Upload Image
+          </button>
+        }
       />
 
       {error && <div className="mb-4"><ErrorBanner message={error} onRetry={refresh} /></div>}
+
+      <UploadImageModal open={showUpload} onClose={() => setShowUpload(false)} onUploaded={refresh} />
 
       {loading && !imageList ? (
         <div className="flex justify-center py-20"><Spinner size={20} /></div>
@@ -44,6 +53,7 @@ export default function ImageList() {
             <thead>
               <tr className="border-b border-steel-800/40">
                 <th className="table-header table-cell">Name</th>
+                <th className="table-header table-cell">Path</th>
                 <th className="table-header table-cell">Format</th>
                 <th className="table-header table-cell">Size</th>
                 <th className="table-header table-cell">Created</th>
@@ -65,6 +75,9 @@ export default function ImageList() {
                         )}
                       </div>
                     </div>
+                  </td>
+                  <td className="table-cell font-mono text-xs text-steel-500 max-w-[200px] truncate" title={img.path}>
+                    {img.path}
                   </td>
                   <td className="table-cell">
                     <span className="badge bg-steel-800/60 text-steel-400 border-steel-700/40">{img.format}</span>
@@ -99,5 +112,98 @@ export default function ImageList() {
         </div>
       )}
     </div>
+  );
+}
+
+function UploadImageModal({ open, onClose, onUploaded }) {
+  const [file, setFile] = useState(null);
+  const [name, setName] = useState('');
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState('');
+  const inputRef = useRef(null);
+
+  const handleFile = (f) => {
+    setFile(f);
+    if (!name && f) {
+      const n = f.name.replace(/\.qcow2$/i, '');
+      setName(n);
+    }
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    const f = e.dataTransfer.files[0];
+    if (f) handleFile(f);
+  };
+
+  const handleSubmit = async () => {
+    if (!file) return;
+    setUploading(true);
+    setError('');
+    try {
+      await imagesApi.upload(file, name.trim() || undefined);
+      onUploaded();
+      onClose();
+      setFile(null);
+      setName('');
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title="Upload Image">
+      <div className="space-y-4">
+        {/* Drop zone */}
+        <div
+          className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors ${
+            file ? 'border-forge-500/60 bg-forge-900/10' : 'border-steel-700/50 hover:border-steel-600/60'
+          }`}
+          onClick={() => inputRef.current?.click()}
+          onDrop={handleDrop}
+          onDragOver={e => e.preventDefault()}
+        >
+          <input
+            ref={inputRef}
+            type="file"
+            accept=".qcow2,.img,.iso"
+            className="hidden"
+            onChange={e => handleFile(e.target.files[0])}
+          />
+          <Upload size={24} className={`mx-auto mb-2 ${file ? 'text-forge-400' : 'text-steel-600'}`} />
+          {file ? (
+            <p className="font-mono text-sm text-forge-400">{file.name}</p>
+          ) : (
+            <>
+              <p className="text-sm text-steel-400">Drop a .qcow2 file here, or click to browse</p>
+              <p className="text-xs text-steel-600 mt-1">Supported: .qcow2, .img, .iso</p>
+            </>
+          )}
+        </div>
+
+        <div>
+          <label className="label">Image Name</label>
+          <input
+            className="input"
+            placeholder="my-image"
+            value={name}
+            onChange={e => setName(e.target.value)}
+          />
+          <p className="text-[10px] font-mono text-steel-600 mt-1">Derived from filename if left blank</p>
+        </div>
+
+        {error && <p className="text-sm text-red-400">Error: {error}</p>}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button className="btn-secondary" onClick={onClose}>Cancel</button>
+          <button className="btn-primary" onClick={handleSubmit} disabled={!file || uploading}>
+            {uploading ? <Spinner size={14} /> : <Upload size={15} />}
+            Upload
+          </button>
+        </div>
+      </div>
+    </Modal>
   );
 }

--- a/web/src/pages/VMList.jsx
+++ b/web/src/pages/VMList.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Plus, Server, Play, Square, Trash2, MoreVertical } from 'lucide-react';
-import { vms } from '../api/client';
+import { vms, images as imagesApi } from '../api/client';
 import { useFetch, useMutation } from '../hooks/useFetch';
 import { PageHeader, StatusBadge, Modal, EmptyState, Spinner, ErrorBanner } from '../components/Shared';
 
@@ -135,9 +135,17 @@ function VMRow({ vm, onNavigate, actionMenu, setActionMenu, onRefresh }) {
 function CreateVMModal({ open, onClose, onCreated }) {
   const [form, setForm] = useState({ name: '', image: '', cpus: 2, ram_mb: 2048, disk_gb: 20, ssh_pub_key: '' });
   const createMut = useMutation(vms.create);
+  const { data: imageList } = useFetch(() => imagesApi.list(), [], 0);
 
   const update = (field) => (e) => setForm(f => ({ ...f, [field]: e.target.value }));
   const updateNum = (field) => (e) => setForm(f => ({ ...f, [field]: parseInt(e.target.value, 10) || 0 }));
+
+  const humanSize = (bytes) => {
+    if (!bytes) return '';
+    if (bytes >= 1073741824) return ` · ${(bytes / 1073741824).toFixed(1)} GB`;
+    if (bytes >= 1048576) return ` · ${(bytes / 1048576).toFixed(1)} MB`;
+    return ` · ${bytes} B`;
+  };
 
   const handleSubmit = async () => {
     try {
@@ -147,6 +155,8 @@ function CreateVMModal({ open, onClose, onCreated }) {
       setForm({ name: '', image: '', cpus: 2, ram_mb: 2048, disk_gb: 20, ssh_pub_key: '' });
     } catch { /* error displayed via mutation */ }
   };
+
+  const noImages = imageList && imageList.length === 0;
 
   return (
     <Modal open={open} onClose={onClose} title="Create Machine" wide>
@@ -158,7 +168,20 @@ function CreateVMModal({ open, onClose, onCreated }) {
           </div>
           <div>
             <label className="label">Base Image</label>
-            <input className="input" placeholder="ubuntu-22.04" value={form.image} onChange={update('image')} />
+            {noImages ? (
+              <div className="input flex items-center text-steel-500 text-xs">
+                No images available — upload one in the Images section first.
+              </div>
+            ) : (
+              <select className="input" value={form.image} onChange={update('image')}>
+                <option value="">Select an image…</option>
+                {(imageList || []).map(img => (
+                  <option key={img.id} value={img.path}>
+                    {img.name}{humanSize(img.size_bytes)}
+                  </option>
+                ))}
+              </select>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
… tests

- GUI: Images page now has Upload Image button with drag-and-drop modal
- GUI: Images page shows filesystem path column for each image
- GUI: Create VM modal uses image dropdown instead of free-text input
- API: POST /api/v1/images/upload endpoint (multipart form, up to 50 GB)
- Storage: ImportImage() saves uploaded file and registers metadata
- Fix: filepath.Join with absolute image path doubled the directory prefix; now uses filepath.IsAbs to use the path directly when absolute
- Fix: VM IP detection now tries guest-agent → DHCP lease → ARP cache
- CLI: --image flag description now mentions absolute path support
- Tests: 151 tests total (up from 83); new coverage for upload handler, ImportImage, domain XML with multiple interface types, NAT attachment
- Docs: README and ARCHITECTURE updated for upload workflow, API table, absolute path usage, and updated test counts