### PR TITLE
Auto-detect VM platform machine type from libvirt capabilities

### DIFF
--- a/internal/vm/domain.go
+++ b/internal/vm/domain.go
@@ -1,11 +1,12 @@
 package vm
 
 import (
+	"bytes"
 	"crypto/rand"
+	"encoding/xml"
 	"fmt"
 	"strings"
 	"text/template"
-	"bytes"
 
 	"github.com/vmsmith/vmsmith/pkg/types"
 )
@@ -15,7 +16,7 @@ const domainXMLTemplate = `<domain type='kvm'>
   <memory unit='MiB'>{{.RAMMB}}</memory>
   <vcpu placement='static'>{{.CPUs}}</vcpu>
   <os>
-    <type arch='x86_64' machine='pc-q35-6.2'>hvm</type>
+    <type arch='x86_64' machine='{{.Machine}}'>hvm</type>
     <boot dev='hd'/>
   </os>
   <features>
@@ -75,6 +76,7 @@ type DomainParams struct {
 	DiskPath     string
 	CloudInitISO string
 	Interfaces   []InterfaceEntry
+	Machine      string // e.g. "pc-q35-6.2" or "pc-q35-rhel9.6.0"
 }
 
 // DomainParamsFromSpec converts a VMSpec into DomainParams, building all
@@ -147,6 +149,7 @@ func DomainParamsFromSpec(spec types.VMSpec, diskPath, cloudInitISO, networkName
 		DiskPath:     diskPath,
 		CloudInitISO: cloudInitISO,
 		Interfaces:   ifaces,
+		Machine:      "pc-q35-6.2",
 	}
 }
 
@@ -163,6 +166,70 @@ func GenerateDomainXML(params DomainParams) (string, error) {
 	}
 
 	return buf.String(), nil
+}
+
+// machineTypeFromCaps parses a libvirt capabilities XML string and returns the
+// best pc-q35-* machine type for x86_64 KVM guests.
+//
+// Selection order:
+//  1. The canonical name of the "q35" alias (e.g. "pc-q35-rhel9.6.0")
+//  2. The first machine whose name starts with "pc-q35-"
+//  3. The provided fallback value
+func machineTypeFromCaps(capsXMLStr, fallback string) string {
+	type capsMachine struct {
+		Canonical string `xml:"canonical,attr"`
+		Name      string `xml:",chardata"`
+	}
+	type capsDomain struct {
+		Type string `xml:"type,attr"`
+	}
+	type capsArch struct {
+		Name     string        `xml:"name,attr"`
+		Machines []capsMachine `xml:"machine"`
+		Domains  []capsDomain  `xml:"domain"`
+	}
+	type capsGuest struct {
+		OSType string   `xml:"os_type"`
+		Arch   capsArch `xml:"arch"`
+	}
+	type capsRoot struct {
+		Guests []capsGuest `xml:"guest"`
+	}
+
+	var caps capsRoot
+	if err := xml.Unmarshal([]byte(capsXMLStr), &caps); err != nil {
+		return fallback
+	}
+
+	for _, guest := range caps.Guests {
+		if guest.OSType != "hvm" || guest.Arch.Name != "x86_64" {
+			continue
+		}
+		hasKVM := false
+		for _, d := range guest.Arch.Domains {
+			if d.Type == "kvm" {
+				hasKVM = true
+				break
+			}
+		}
+		if !hasKVM {
+			continue
+		}
+		// Prefer the canonical target of the "q35" alias.
+		for _, m := range guest.Arch.Machines {
+			if m.Name == "q35" && m.Canonical != "" {
+				return m.Canonical
+			}
+		}
+		// Fall back to the first pc-q35-* machine listed.
+		for _, m := range guest.Arch.Machines {
+			if strings.HasPrefix(m.Name, "pc-q35-") {
+				return m.Name
+			}
+		}
+	}
+
+	return fallback
 }
 
 // generateMAC creates a random MAC address with the local/unicast prefix 52:54:00

--- a/internal/vm/domain_test.go
+++ b/internal/vm/domain_test.go
@@ -375,6 +375,96 @@ func TestGenerateNetworkConfig_RouteMetric(t *testing.T) {
 	}
 }
 
+func TestMachineTypeFromCaps(t *testing.T) {
+	rhel96Caps := `<capabilities>
+  <guest>
+    <os_type>hvm</os_type>
+    <arch name='x86_64'>
+      <machine canonical='pc-q35-rhel9.6.0' maxCpus='255'>q35</machine>
+      <machine maxCpus='255'>pc-q35-rhel9.6.0</machine>
+      <machine maxCpus='255'>pc-q35-rhel9.5.0</machine>
+      <domain type='kvm'/>
+    </arch>
+  </guest>
+</capabilities>`
+
+	upstreamCaps := `<capabilities>
+  <guest>
+    <os_type>hvm</os_type>
+    <arch name='x86_64'>
+      <machine maxCpus='255'>pc-q35-9.2</machine>
+      <machine maxCpus='255'>pc-q35-9.1</machine>
+      <domain type='kvm'/>
+    </arch>
+  </guest>
+</capabilities>`
+
+	noKVMCaps := `<capabilities>
+  <guest>
+    <os_type>hvm</os_type>
+    <arch name='x86_64'>
+      <machine maxCpus='255'>pc-q35-9.2</machine>
+      <domain type='qemu'/>
+    </arch>
+  </guest>
+</capabilities>`
+
+	tests := []struct {
+		name     string
+		caps     string
+		fallback string
+		want     string
+	}{
+		{
+			name:     "rhel9.6 q35 alias with canonical",
+			caps:     rhel96Caps,
+			fallback: "pc-q35-6.2",
+			want:     "pc-q35-rhel9.6.0",
+		},
+		{
+			name:     "upstream first pc-q35 listed",
+			caps:     upstreamCaps,
+			fallback: "pc-q35-6.2",
+			want:     "pc-q35-9.2",
+		},
+		{
+			name:     "no kvm domain falls back",
+			caps:     noKVMCaps,
+			fallback: "pc-q35-6.2",
+			want:     "pc-q35-6.2",
+		},
+		{
+			name:     "invalid xml falls back",
+			caps:     "not xml",
+			fallback: "pc-q35-6.2",
+			want:     "pc-q35-6.2",
+		},
+		{
+			name:     "empty caps falls back",
+			caps:     "<capabilities/>",
+			fallback: "pc-q35-6.2",
+			want:     "pc-q35-6.2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := machineTypeFromCaps(tt.caps, tt.fallback)
+			if got != tt.want {
+				t.Errorf("machineTypeFromCaps = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDomainParamsFromSpec_DefaultMachine(t *testing.T) {
+	spec := types.VMSpec{Name: "test", CPUs: 1, RAMMB: 1024}
+	params := DomainParamsFromSpec(spec, "/tmp/disk.qcow2", "", "vmsmith-net")
+	if params.Machine != "pc-q35-6.2" {
+		t.Errorf("default Machine = %q, want %q", params.Machine, "pc-q35-6.2")
+	}
+}
+
 func TestHasStaticIPs(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/vm/lifecycle.go
+++ b/internal/vm/lifecycle.go
@@ -112,6 +112,7 @@ func (m *LibvirtManager) Create(ctx context.Context, spec types.VMSpec) (*types.
 
 	// Generate and define domain XML
 	params := DomainParamsFromSpec(spec, diskPath, cloudInitISO, m.cfg.Network.Name)
+	params.Machine = detectMachineType(m.conn)
 	xmlDoc, err := GenerateDomainXML(params)
 	if err != nil {
 		return nil, err
@@ -494,6 +495,17 @@ func domainStateToVMState(dom *libvirt.Domain) types.VMState {
 	default:
 		return types.VMStateUnknown
 	}
+}
+
+// detectMachineType queries libvirt capabilities to find the best pc-q35-*
+// machine type for x86_64 KVM guests, falling back to "pc-q35-6.2".
+func detectMachineType(conn *libvirt.Connect) string {
+	const fallback = "pc-q35-6.2"
+	capsXMLStr, err := conn.GetCapabilities()
+	if err != nil {
+		return fallback
+	}
+	return machineTypeFromCaps(capsXMLStr, fallback)
 }
 
 func getDomainIP(dom *libvirt.Domain) string {


### PR DESCRIPTION
Previously the domain XML hardcoded machine='pc-q35-6.2', which fails on hosts that only support distro-specific types like pc-q35-rhel9.6.0.

Now Create() queries conn.GetCapabilities() and selects the right pc-q35-* machine for the x86_64 KVM guest: it prefers the canonical name behind the 'q35' alias (covers RHEL/CentOS naming), then falls back to the first pc-q35-* entry, and finally to the original default 'pc-q35-6.2' if detection fails.

The parsing logic lives in machineTypeFromCaps (domain.go) so it can be exercised by pure-Go unit tests without CGO.

https://claude.ai/code/session_018DFfq5ZhkVsAXcdDUnGBxJ