### PR TITLE
fix: always generate cloud-init ISO with network-config for eth0

### DIFF
--- a/internal/vm/lifecycle.go
+++ b/internal/vm/lifecycle.go
@@ -100,16 +100,14 @@ func (m *LibvirtManager) Create(ctx context.Context, spec types.VMSpec) (*types.
 		return nil, fmt.Errorf("creating overlay disk: %w", err)
 	}
 
-	// Create cloud-init ISO if SSH key, cloud-init file, or extra network interfaces
-	// are present. Extra interfaces need a network-config entry so cloud-init
-	// brings them up (even DHCP ones — without it the OS never configures them).
-	var cloudInitISO string
-	needsCloudInit := spec.SSHPubKey != "" || spec.CloudInitFile != "" || len(spec.Networks) > 0
-	if needsCloudInit {
-		cloudInitISO = filepath.Join(vmDir, "cidata.iso")
-		if err := createCloudInitISO(cloudInitISO, spec); err != nil {
-			return nil, fmt.Errorf("creating cloud-init ISO: %w", err)
-		}
+	// Always create a cloud-init ISO. Rocky Linux (and other RHEL-based images)
+	// rely entirely on cloud-init to bring up eth0 with DHCP — without it the
+	// primary NAT interface is never configured and the VM gets no IP address.
+	// Ubuntu cloud images have fallback network config so they work either way,
+	// but generating the ISO unconditionally is correct for all distros.
+	cloudInitISO := filepath.Join(vmDir, "cidata.iso")
+	if err := createCloudInitISO(cloudInitISO, spec); err != nil {
+		return nil, fmt.Errorf("creating cloud-init ISO: %w", err)
 	}
 
 	// Generate and define domain XML
@@ -411,14 +409,12 @@ func createCloudInitISO(isoPath string, spec types.VMSpec) error {
 		return err
 	}
 
-	// Write network-config for any extra interfaces (DHCP or static).
-	// Without this entry cloud-init leaves extra interfaces unconfigured.
-	// Interface naming: eth0 = NAT (DHCP), eth1..ethN = extra attachments in order.
-	if len(spec.Networks) > 0 {
-		netCfg := generateNetworkConfig(spec.Networks)
-		if err := os.WriteFile(filepath.Join(tmpDir, "network-config"), []byte(netCfg), 0644); err != nil {
-			return err
-		}
+	// Always write network-config so cloud-init configures eth0 (NAT/DHCP) on
+	// every distro, including RHEL-based images like Rocky Linux that do not
+	// bring up interfaces without explicit cloud-init direction.
+	netCfg := generateNetworkConfig(spec.Networks)
+	if err := os.WriteFile(filepath.Join(tmpDir, "network-config"), []byte(netCfg), 0644); err != nil {
+		return err
 	}
 
 	// Generate ISO


### PR DESCRIPTION
Rocky Linux (and RHEL-based) cloud images rely on cloud-init to bring up eth0 with DHCP. Previously the cloud-init ISO was only created when an SSH key, custom cloud-init file, or extra network interfaces were present — leaving basic VMs on Rocky 9 with no IP address.

Ubuntu cloud images have fallback network config so they worked without cloud-init, masking the bug.

Fix: unconditionally create the cloud-init ISO and always include a network-config that enables DHCP on eth0, regardless of other options.

https://claude.ai/code/session_01RVBeQRfL2xJKF9NJqUAoAc