### PR TITLE
docs: add weekly digest for 2026-04-16

### DIFF
--- a/docs/weekly-digests/2026-04-16.md
+++ b/docs/weekly-digests/2026-04-16.md
@@ -1,0 +1,119 @@
+# Weekly Digest — 2026-04-16
+
+**Period:** 2026-04-11 to 2026-04-18
+**Generated:** 2026-04-18
+
+---
+
+## Open Pull Requests (4)
+
+Sorted by oldest first.
+
+### 1. feat: add daemon autocert TLS support — [#88](https://github.com/chinmay28/VMSmith/pull/88)
+
+| Field | Value |
+|---|---|
+| **Author** | march26bot |
+| **Opened** | 2026-04-04 (14 days ago) |
+| **Review status** | Changes requested (3 review rounds by chinmay28) |
+| **CI status** | Passing (backend + frontend) |
+| **Merge conflicts** | None — base is up to date |
+
+> **Flagged:** Open for more than 3 days. Blocked on committing `go mod tidy` output (`go.mod` + `go.sum`) for the new `golang.org/x/crypto` dependency. Implementation itself has been approved across all three reviews.
+
+### 2. feat: implement snapshot retention limit and roadmap updates — [#105](https://github.com/chinmay28/VMSmith/pull/105)
+
+| Field | Value |
+|---|---|
+| **Author** | april26bot |
+| **Opened** | 2026-04-12 (6 days ago) |
+| **Review status** | Changes requested (3 review rounds by chinmay28) |
+| **CI status** | Passing (backend + frontend) |
+| **Merge conflicts** | None — base is up to date |
+
+> **Flagged:** Open for more than 3 days. Blocked on a missing `"fmt"` import in `quota_manager_test.go`. Core retention logic (create-first-then-prune) and tests are otherwise approved.
+
+### 3. feat(api): add VM template storage and endpoints — [#107](https://github.com/chinmay28/VMSmith/pull/107)
+
+| Field | Value |
+|---|---|
+| **Author** | march26bot |
+| **Opened** | 2026-04-17 (1 day ago) |
+| **Review status** | Awaiting review |
+| **CI status** | Passing (backend + frontend) |
+| **Merge conflicts** | None — base is up to date |
+
+### 4. feat(web): paginate log viewer results — [#108](https://github.com/chinmay28/VMSmith/pull/108)
+
+| Field | Value |
+|---|---|
+| **Author** | march26bot |
+| **Opened** | 2026-04-17 (1 day ago) |
+| **Review status** | Awaiting review |
+| **CI status** | Passing (backend + frontend) |
+| **Merge conflicts** | None — base is up to date |
+
+---
+
+## Commits Merged to Main (Last 7 Days)
+
+**8 commits** merged between 2026-04-11 and 2026-04-18:
+
+| Date | Commit | Description |
+|---|---|---|
+| 2026-04-17 | `b68e5c7` | fix(api): standardize remaining error response codes (#106) |
+| 2026-04-16 | `ee62b5d` | test: add API 400-path integration coverage (#87) |
+| 2026-04-16 | `4a5fc55` | scripts: add release install helper (#100) |
+| 2026-04-16 | `c451f12` | feat(web): add server-side pagination controls (#102) |
+| 2026-04-16 | `cea2674` | feat(daemon): add graceful shutdown for roadmap item 3.3.4 (#101) |
+| 2026-04-16 | `19636e4` | feat(api): enforce configured VM quotas (#103) |
+| 2026-04-16 | `f1a220a` | docs: mark completed validation roadmap items (#104) |
+| 2026-04-11 | `c2a41ea` | cli: fix bulk stop past-tense output (#94) |
+
+---
+
+## Roadmap Progress
+
+**57 of 105 items completed (54.3%) — 45.7% remaining**
+
+| Phase | Done | Total | Progress |
+|---|---|---|---|
+| Phase 1: Foundation & Quality | 17 | 18 | 94% |
+| Phase 2: Core Feature Additions | 9 | 21 | 43% |
+| Phase 3: Operational Excellence | 17 | 19 | 89% |
+| Phase 4: Monitoring & Observability | 0 | 14 | 0% |
+| Phase 5: Advanced Features | 3 | 21 | 14% |
+| Phase 6: Developer & Community | 11 | 12 | 92% |
+
+### Not yet started (0% complete)
+
+- Phase 2.1 — VM Cloning (7 items)
+- Phase 4.1 — VM Resource Metrics (5 items)
+- Phase 4.2 — Event System & Notifications (6 items)
+- Phase 4.3 — OpenAPI / Swagger Spec (3 items)
+- Phase 5.1 — VNC Console Access (4 items)
+- Phase 5.2 — Scheduled Operations (6 items)
+- Phase 5.3 — VM Import/Export OVA/OVF (3 items)
+- Phase 5.5 — Multi-Host Management (4 items)
+
+### In progress (partially complete)
+
+- Phase 2.4 — VM Templates (0/5 done; PR #107 adds items 2.4.1 and 2.4.2)
+- Phase 5.4 — Pagination & Filtering (3/4 done; PR #108 covers item 5.4.3)
+- Phase 3.2 — TLS/HTTPS (3/4 done; PR #88 covers item 3.2.3)
+
+### Remaining individual items in otherwise-complete sections
+
+- 1.1.6 — Branch protection rules for `main`
+- 3.1.5 — Role-based access control
+- 6.3.4 — Video/GIF demos for README
+
+---
+
+## Highlights and Action Items
+
+- **2 PRs flagged as stale** (open > 3 days): #88 and #105 are both blocked on minor fixes (missing imports / `go mod tidy`). No code logic concerns remain.
+- **0 failing CI checks** across all open PRs.
+- **0 merge conflicts** — all PR branches are up to date with `main`.
+- **Strong merge velocity** this week: 8 commits landed, spanning error handling, pagination, quotas, graceful shutdown, and install tooling.
+- **Phases 1, 3, and 6 are nearly complete** (89-94%). The main remaining work is in Phases 4 and 5 (monitoring, observability, and advanced features).


### PR DESCRIPTION
## Summary
- Adds `docs/weekly-digests/2026-04-16.md` covering the week of Apr 11–18
- Reports on 4 open PRs (review status, CI, conflicts), 8 merged commits, and roadmap progress (57/105 items done, 45.7% remaining)
- Flags 2 stale PRs (#88 open 14 days, #105 open 6 days) both blocked on minor import fixes

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm PR/commit counts and roadmap percentages match repo state

https://claude.ai/code/session_014JkeR7xJx7gpsGp3SK529i