### PR TITLE
docs: add weekly digest for 2026-04-18

### DIFF
--- a/docs/weekly-digests/2026-04-18.md
+++ b/docs/weekly-digests/2026-04-18.md
@@ -1,0 +1,121 @@
+# Weekly Digest — 2026-04-18
+
+**Period:** 2026-04-11 to 2026-04-18
+**Generated:** 2026-04-18
+
+---
+
+## Open Pull Requests (3)
+
+Sorted by oldest first.
+
+### 1. feat: add daemon autocert TLS support — [#88](https://github.com/chinmay28/VMSmith/pull/88)
+
+| Field | Value |
+|---|---|
+| **Author** | march26bot |
+| **Opened** | 2026-04-04 (14 days ago) |
+| **Review status** | Approved (after 4 review rounds by chinmay28; `go mod tidy` blocker resolved) |
+| **CI status** | Passing (backend + frontend) |
+| **Merge conflicts** | Branch is behind `main` — needs rebase/update |
+
+> **Flagged — open > 3 days.** This PR was blocked for two weeks on missing `go.sum`/`go.mod` entries for the `golang.org/x/crypto` dependency. The blocker is now resolved and the latest review is **APPROVED**. Ready to merge once the branch is updated against `main`.
+
+### 2. feat(api): add VM template storage and endpoints — [#107](https://github.com/chinmay28/VMSmith/pull/107)
+
+| Field | Value |
+|---|---|
+| **Author** | march26bot |
+| **Opened** | 2026-04-17 (1 day ago) |
+| **Review status** | Approved (by chinmay28) |
+| **CI status** | Passing (backend + frontend) |
+| **Merge conflicts** | Branch is behind `main` — needs rebase/update |
+
+> Implements roadmap items 2.4.1 and 2.4.2 (VMTemplate type + CRUD endpoints). Clean implementation following existing patterns.
+
+### 3. feat(web): paginate log viewer results — [#108](https://github.com/chinmay28/VMSmith/pull/108)
+
+| Field | Value |
+|---|---|
+| **Author** | march26bot |
+| **Opened** | 2026-04-17 (< 1 day ago) |
+| **Review status** | Approved (by chinmay28) |
+| **CI status** | Passing (backend + frontend) |
+| **Merge conflicts** | Branch is behind `main` — needs rebase/update |
+
+> Completes roadmap item 5.4.3 (server-side pagination for log viewer). Reuses existing pagination components.
+
+---
+
+## Commits Merged to Main (Last 7 Days)
+
+**10 commits** merged between 2026-04-11 and 2026-04-18:
+
+| Date | Commit | Description |
+|---|---|---|
+| 2026-04-18 | `befa4eb` | docs: add weekly digest for 2026-04-16 (#109) |
+| 2026-04-18 | `657cc4f` | feat: implement snapshot retention limit and roadmap updates (#105) |
+| 2026-04-17 | `b68e5c7` | fix(api): standardize remaining error response codes (#106) |
+| 2026-04-16 | `ee62b5d` | test: add API 400-path integration coverage (#87) |
+| 2026-04-16 | `4a5fc55` | scripts: add release install helper (#100) |
+| 2026-04-16 | `c451f12` | feat(web): add server-side pagination controls (#102) |
+| 2026-04-16 | `cea2674` | feat(daemon): add graceful shutdown for roadmap item 3.3.4 (#101) |
+| 2026-04-16 | `19636e4` | feat(api): enforce configured VM quotas (#103) |
+| 2026-04-16 | `f1a220a` | docs: mark completed validation roadmap items (#104) |
+| 2026-04-11 | `c2a41ea` | cli: fix bulk stop past-tense output (#94) |
+
+---
+
+## Roadmap Progress
+
+**58 of 105 items completed (55.2%) — 44.8% remaining**
+
+| Phase | Done | Total | Progress |
+|---|---|---|---|
+| Phase 1: Foundation & Quality | 17 | 18 | 94% |
+| Phase 2: Core Feature Additions | 9 | 21 | 43% |
+| Phase 3: Operational Excellence | 17 | 19 | 89% |
+| Phase 4: Monitoring & Observability | 0 | 14 | 0% |
+| Phase 5: Advanced Features | 4 | 21 | 19% |
+| Phase 6: Developer & Community | 11 | 12 | 92% |
+
+### Changes since last digest (2026-04-16)
+
+- +1 roadmap item completed: **5.2.6** — Snapshot retention limit (via merged PR #105)
+- +2 commits merged: snapshot retention (#105) and weekly digest (#109)
+- PR #105 (snapshot retention) resolved its import blocker and was merged
+- All 3 remaining open PRs now have **approved** reviews (up from 0 last week)
+
+### Not yet started (0% complete)
+
+- Phase 2.1 — VM Cloning (7 items)
+- Phase 4.1 — VM Resource Metrics (5 items)
+- Phase 4.2 — Event System & Notifications (6 items)
+- Phase 4.3 — OpenAPI / Swagger Spec (3 items)
+- Phase 5.1 — VNC Console Access (4 items)
+- Phase 5.3 — VM Import/Export OVA/OVF (3 items)
+- Phase 5.5 — Multi-Host Management (4 items)
+
+### In progress (partially complete)
+
+- Phase 2.4 — VM Templates (0/5 done; PR #107 adds items 2.4.1 and 2.4.2)
+- Phase 5.2 — Scheduled Operations (1/6 done)
+- Phase 5.4 — Pagination & Filtering (3/4 done; PR #108 covers item 5.4.3)
+- Phase 3.2 — TLS/HTTPS (3/4 done; PR #88 covers item 3.2.3)
+
+### Remaining individual items in otherwise-complete sections
+
+- 1.1.6 — Branch protection rules for `main`
+- 3.1.5 — Role-based access control
+- 6.3.4 — Video/GIF demos for README
+
+---
+
+## Highlights and Action Items
+
+- **1 PR flagged as stale** (open > 3 days): #88 has been open 14 days but is now approved — ready to merge after branch update.
+- **0 failing CI checks** across all open PRs.
+- **All 3 open PRs are approved** and ready to merge (pending branch updates against `main`).
+- **Strong merge velocity**: 10 commits landed this week, covering snapshot retention, error handling, pagination, quotas, graceful shutdown, install tooling, and test coverage.
+- **Phases 1, 3, and 6 are nearly complete** (89–94%). Main remaining work is in Phases 4 and 5 (monitoring, observability, and advanced features).
+- **If all 3 open PRs merge**, roadmap progress would jump to 61/105 (58.1% done).


### PR DESCRIPTION
## Summary
- Adds `docs/weekly-digests/2026-04-18.md` covering the week of Apr 11–18
- Reports on 3 open PRs (all approved, 1 flagged stale), 10 merged commits, and roadmap progress (58/105 items done, 44.8% remaining)
- Notes that all open PRs are approved and ready to merge

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm PR/commit counts and roadmap percentages match repo state

https://claude.ai/code/session_012itQQXy5NxbP7kZYFb5iob