### PR TITLE
fix(web): keep log viewer pinned where the user scrolled

### DIFF
--- a/web/src/pages/LogViewer.jsx
+++ b/web/src/pages/LogViewer.jsx
@@ -35,8 +35,12 @@ export default function LogViewer() {
   const [perPage, setPerPage] = useState(DEFAULT_PER_PAGE);
   const [autoScroll, setAutoScroll] = useState(true);
   const [paused, setPaused] = useState(false);
-  const bottomRef = useRef(null);
   const listRef = useRef(null);
+  const autoScrollRef = useRef(true);
+
+  useEffect(() => {
+    autoScrollRef.current = autoScroll;
+  }, [autoScroll]);
 
   const fetchLogs = useCallback(async () => {
     if (paused) return;
@@ -65,18 +69,23 @@ export default function LogViewer() {
     setPage(1);
   }, [levelFilter, sourceFilter]);
 
-  // Auto-scroll to bottom when new entries arrive.
+  // Auto-scroll to bottom when new entries arrive — only when the user
+  // is already pinned to the bottom. Use direct scrollTop (not smooth
+  // scrollIntoView) so we don't fire intermediate scroll events that
+  // would race with the user's own scrolling.
   useEffect(() => {
-    if (autoScroll && bottomRef.current) {
-      bottomRef.current.scrollIntoView({ behavior: 'smooth' });
-    }
+    if (!autoScroll || !listRef.current) return;
+    const el = listRef.current;
+    el.scrollTop = el.scrollHeight;
   }, [entries, autoScroll]);
 
   const handleScroll = () => {
     if (!listRef.current) return;
     const { scrollTop, scrollHeight, clientHeight } = listRef.current;
     const atBottom = scrollHeight - scrollTop - clientHeight < 40;
-    setAutoScroll(atBottom);
+    if (atBottom !== autoScrollRef.current) {
+      setAutoScroll(atBottom);
+    }
   };
 
   const filtered = entries.filter(e => LEVEL_ORDER[e.level] >= LEVEL_ORDER[levelFilter]);
@@ -181,7 +190,6 @@ export default function LogViewer() {
             </tbody>
           </table>
         )}
-        <div ref={bottomRef} />
       </div>
 
       {totalEntries > 0 && (
@@ -205,7 +213,9 @@ export default function LogViewer() {
           className="absolute bottom-6 right-6 btn-secondary text-xs py-1 px-3 flex items-center gap-1 shadow-lg"
           onClick={() => {
             setAutoScroll(true);
-            bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+            if (listRef.current) {
+              listRef.current.scrollTop = listRef.current.scrollHeight;
+            }
           }}
         >
           <ChevronDown size={13} /> Latest


### PR DESCRIPTION
## Summary

The Logs tab snapped to the bottom on every 3-second poll, even when the user had scrolled up. Two issues:

- `bottomRef.current.scrollIntoView({ behavior: 'smooth' })` fired intermediate scroll events during the animation, which the `onScroll` handler interpreted, racing with the user's input. `scrollIntoView` also scrolls every scrollable ancestor, not just the log container.
- Polling reassigned `entries` to a new array every cycle, retriggering the auto-scroll effect even when the user had scrolled away.

Fix in `web/src/pages/LogViewer.jsx`:

- Replace `scrollIntoView` with direct `listRef.current.scrollTop = listRef.current.scrollHeight` — instant, single scroll event, scoped to the log container.
- `handleScroll` only calls `setAutoScroll` when the bottom threshold is actually crossed, reading the current value via a ref to avoid stale-closure flips.
- The "Latest" button now uses the same direct scrollTop approach.

Net effect: when you scroll up, autoScroll flips off on that one event and stays off through subsequent polls until you scroll back to within 40px of the bottom.

## Test plan

- [x] `npx vite build` passes locally
- [ ] Manual: open the Logs tab, scroll up — the view stays put through poll cycles; click "Latest" or scroll near the bottom and the view re-pins
- [ ] CI: backend lint/build/tests, frontend build + mock GUI tests

https://claude.ai/code/session_01VeBiUDvZ8dcdWFpBQu6jkX

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeBiUDvZ8dcdWFpBQu6jkX)_