### PR TITLE
docs(roadmap): refine 4.2 event system architecture

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -74,10 +74,13 @@ vmsmith/
 │       ├── embed.go                 # go:embed dist/*
 │       └── dist/                    # Built SPA (gitignored; built by `make build`)
 ├── pkg/types/
-│   ├── vm.go                        # VM, VMSpec, VMState
+│   ├── vm.go                        # VM, VMSpec, VMUpdateSpec, VMState
 │   ├── snapshot.go                  # Snapshot
 │   ├── image.go                     # Image
 │   ├── network.go                   # NetworkAttachment, PortForward, HostInterface
+│   ├── template.go                  # VMTemplate
+│   ├── quota.go                     # Quota usage response types
+│   ├── event.go                     # Event (system / VM lifecycle audit log)
 │   └── errors.go                    # Typed API errors
 ├── web/                             # React source
 │   ├── src/api/client.js            # REST API client (vms, snapshots, images, ports, host, logs)
@@ -396,11 +399,12 @@ All endpoints are prefixed `/api/v1/`.
 
 | Method | Path                                     | Description                   |
 |--------|------------------------------------------|-------------------------------|
-| GET    | /vms                                     | List all VMs                  |
-| POST   | /vms                                     | Create a new VM               |
+| GET    | /vms                                     | List all VMs (`?tag=`, `?status=`, `?page=`, `?per_page=`) |
+| POST   | /vms                                     | Create a new VM (accepts `template_id` for default merge) |
 | GET    | /vms/{id}                                | Get VM details                |
-| PATCH  | /vms/{id}                                | Update VM resources (CPU/RAM/disk/IP) |
-| GET    | /quotas/usage                             | Current quota allocation vs configured limits |
+| PATCH  | /vms/{id}                                | Update VM resources (CPU/RAM/disk/IP/tags) |
+| POST   | /vms/{id}/clone                          | Clone a VM (copies disk, generates new MAC + IP reservation) |
+| POST   | /vms/bulk                                | Bulk start/stop/delete across multiple VM IDs |
 | POST   | /vms/{id}/start                          | Start a stopped VM            |
 | POST   | /vms/{id}/stop                           | Stop a running VM             |
 | DELETE | /vms/{id}                                | Delete a VM                   |
@@ -408,18 +412,26 @@ All endpoints are prefixed `/api/v1/`.
 | POST   | /vms/{id}/snapshots                      | Create snapshot               |
 | POST   | /vms/{id}/snapshots/{name}/restore       | Restore snapshot              |
 | DELETE | /vms/{id}/snapshots/{name}               | Delete snapshot               |
-| GET    | /images                                  | List images                   |
+| GET    | /images                                  | List images (`?page=`, `?per_page=`) |
 | POST   | /images                                  | Create image from VM disk     |
 | POST   | /images/upload                           | Upload qcow2 file             |
 | DELETE | /images/{id}                             | Delete image                  |
 | GET    | /images/{id}/download                    | Download image file           |
+| GET    | /templates                               | List VM templates             |
+| POST   | /templates                               | Create a VM template          |
+| DELETE | /templates/{id}                          | Delete a VM template          |
 | GET    | /vms/{id}/ports                          | List port forwards            |
 | POST   | /vms/{id}/ports                          | Add port forward              |
 | DELETE | /vms/{id}/ports/{portId}                 | Remove port forward           |
 | GET    | /host/interfaces                         | List host network interfaces  |
+| GET    | /host/stats                              | Host CPU/RAM/disk usage and VM count |
+| GET    | /quotas/usage                            | Current quota allocation vs configured limits |
+| GET    | /events                                  | Query lifecycle/audit events (`?vm_id=`, `?since=`, pagination); see Phase 4.2 of the roadmap for streaming + filter expansion |
 | GET    | /logs                                    | Query structured log entries  |
 
 The `/logs` endpoint supports query parameters: `level` (min level: debug/info/warn/error), `limit` (max entries, capped at 2000), `since` (RFC3339Nano timestamp), `source` (daemon/api/cli).
+
+The `/events` endpoint returns events from the `events` bucket in reverse-chronological order. Query parameters: `vm_id` (exact match), `since` (RFC3339Nano timestamp), `page`, `per_page`. The full event schema (sources, severity, attributes, actor) and `GET /events/stream` (SSE) are tracked in Phase 4.2 of the roadmap.
 
 ---
 
@@ -514,7 +526,11 @@ quotas:
 |----------------|----------------------------|------------------------------|
 | `vms`          | VM ID                      | JSON `types.VM`              |
 | `images`       | image ID                   | JSON `types.Image`           |
+| `snapshots`    | `{vmID}/{name}`            | JSON `types.Snapshot`        |
+| `templates`    | template ID                | JSON `types.VMTemplate`      |
 | `port_forwards`| `{vmID}/{hostPort}`        | JSON `types.PortForward`     |
+| `events`       | event ID                   | JSON `types.Event` (lifecycle/audit log; see Phase 4.2 for indexing + retention) |
+| `config`       | config key                 | JSON daemon-managed runtime state |
 
 ---
 
@@ -589,9 +605,11 @@ make test-all         # everything
 
 ## Future Enhancements
 
-- **KubeVirt backend** — `KubeVirtVMManager` behind the same interface
+Active feature work — including VM-level metrics, the event bus / SSE / webhook subsystem, browser-based VNC + serial console, and the cron-style scheduler — is tracked in [`ROADMAP.md`](ROADMAP.md) (Phases 4.1, 4.2, 5.1, 5.2). VM templates already shipped (`/api/v1/templates`).
+
+Longer-horizon items not yet promoted to the roadmap:
+
+- **KubeVirt backend** — `KubeVirtVMManager` behind the same `vm.Manager` interface
 - **Second NAT networks** — create per-VM isolated private subnets
-- **VNC/SPICE proxy** — browser-accessible console via the web GUI
-- **VM templates** — named resource presets ("small", "medium", "large")
 - **OCI image support** — pull cloud images from container registries
-- **Cluster mode** — multiple VM Smith hosts with shared image catalog
+- **Cluster mode** — multiple VM Smith hosts with shared image catalog (early sketch in roadmap Phase 5.5)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,7 @@
 # VMSmith Project Roadmap
 
 > **Last updated:** 2026-04-28
-> **Status:** Active roadmap — foundation work, auth/TLS/systemd/quotas, templates, bulk ops, host dashboard stats, and frontend pagination are now complete; the main remaining gaps are cloning, VM-level metrics, events/notifications, OpenAPI tooling, and advanced operations features
+> **Status:** Active roadmap — foundation work, auth/TLS/systemd/quotas, templates, bulk ops, host dashboard stats, and frontend pagination are now complete; the main remaining gaps are cloning, VM-level metrics, events/notifications, OpenAPI tooling, and advanced operations features. Phase 4.1, 4.2, 5.1, and 5.2 refined 2026-04-28 to capture the partial implementations already in tree and to flesh out the missing architecture.
 
 This document outlines planned improvements, new features, and technical debt items for VMSmith. Tasks are organized into phases by theme, with rough effort estimates and dependency notes.
 
@@ -171,28 +171,235 @@ Prevent VMs from consuming all host resources.
 
 ### 4.1 VM Resource Metrics
 
-Users have no visibility into what's happening inside VMs.
+Users have no visibility into what's happening inside VMs. Per-host stats already exist (`GET /api/v1/host/stats`, on-demand sample, see `internal/api/host_stats.go`); per-VM time-series and history are missing.
+
+#### 4.1.0 Architectural overview
+
+**Sampling.** A single goroutine in a new `internal/metrics/` package polls libvirt's bulk stats API every `daemon.metrics.sample_interval` (default 10s) using `Connect.GetAllDomainStats(stats, flags)` with the bitmask `STATS_STATE | STATS_CPU_TOTAL | STATS_BALLOON | STATS_VCPU | STATS_INTERFACE | STATS_BLOCK`. One bulk call returns stats for every running domain in milliseconds — far cheaper than per-VM calls.
+
+**Counter → rate conversion.** libvirt returns cumulative counters (CPU nanoseconds, bytes in/out, blocks read/written). Charts need rates. The collector keeps the previous sample in memory and computes deltas:
+
+| Metric | libvirt field | Computed |
+|---|---|---|
+| CPU % | `cpu.time` (ns, cumulative) | `(Δns / Δt_ns / vcpus) * 100` clamped to [0, 100*vcpus] |
+| RAM used MB | `balloon.rss` if present, else `balloon.current` | absolute |
+| RAM available MB | `balloon.available - balloon.unused` (guest-agent dependent) | absolute, may be missing |
+| Disk read B/s | `block.<n>.rd.bytes` summed across disks | `Δ / Δt_seconds` |
+| Disk write B/s | `block.<n>.wr.bytes` summed | `Δ / Δt_seconds` |
+| Net rx B/s | `net.<n>.rx.bytes` summed across interfaces | `Δ / Δt_seconds` |
+| Net tx B/s | `net.<n>.tx.bytes` summed | `Δ / Δt_seconds` |
+
+First sample after a VM starts produces no rate (no prior counter); the API marks it `null` and the chart skips. Counter resets (libvirt reports a smaller value than the prior sample — happens after VM restart) reset the baseline; rate for that interval is `null` rather than negative.
+
+**In-memory ring buffer per VM.** A fixed-size circular buffer of `MetricSample` per VM ID:
+
+```go
+type MetricSample struct {
+    Timestamp     time.Time `json:"timestamp"`
+    CPUPercent    *float64  `json:"cpu_percent,omitempty"`     // pointer for null-on-reset
+    MemUsedMB     *uint64   `json:"mem_used_mb,omitempty"`
+    MemAvailMB    *uint64   `json:"mem_avail_mb,omitempty"`
+    DiskReadBps   *uint64   `json:"disk_read_bps,omitempty"`
+    DiskWriteBps  *uint64   `json:"disk_write_bps,omitempty"`
+    NetRxBps      *uint64   `json:"net_rx_bps,omitempty"`
+    NetTxBps      *uint64   `json:"net_tx_bps,omitempty"`
+}
+```
+
+Buffer size = `daemon.metrics.history_size` (default 360 samples = 1 hour at 10s). Memory cost: ~80 bytes per sample × 360 × 100 VMs ≈ 2.8 MB worst case.
+
+**Why in-memory only (v1).** Persisting metrics to bbolt is rejected for v1:
+1. 10s sampling × 100 VMs × 30 days = 25.9 M samples per bucket. bbolt is not a TSDB; range scans get expensive and write amplification is high.
+2. The compelling use case is "what is this VM doing right now / in the last hour" — covered by an in-memory ring.
+3. Long-term metrics belong in a real TSDB. Defer to 4.1.6 (Prometheus exporter), which lets operators ship metrics to Prometheus/VictoriaMetrics/Grafana Cloud without us reinventing storage.
+
+If durable metrics become a requirement before 4.1.6, the API shape stays the same — only the storage backend swaps.
+
+**Stale-sample handling.** When a VM stops, its ring keeps the last samples but adds no new ones. `GET /api/v1/vms/{id}/stats` includes `state` and `last_sampled_at` in the response so the UI can mark the chart "VM stopped at <time>". Rings for deleted VMs are pruned on the next sweep (which checks each ring's owner against `Store.GetVM`). Rings for VMs that vanish from `GetAllDomainStats` for >5 minutes are also pruned to handle libvirt restarts.
+
+**Metrics manager API.**
+```go
+type Manager interface {
+    Start(ctx context.Context) error  // launches the sampler goroutine
+    Stop() error
+    Snapshot(vmID string) (*VMStatsSnapshot, error)  // current + history
+    Subscribe(vmID string) (<-chan MetricSample, cancel func())  // for SSE / future events
+}
+```
+
+The subscription path is what powers real-time charts: when 4.2 (events) lands, the metrics manager publishes `metrics.sample` events at a sampled-down rate (1/min) so the events stream stays a low-traffic audit log; the `Subscribe` path is the high-frequency path the SSE chart endpoint uses directly.
+
+**API contract (`GET /api/v1/vms/{id}/stats`).**
+
+```jsonc
+{
+  "vm_id": "vm-1741234567890123",
+  "state": "running",
+  "last_sampled_at": "2026-04-28T12:34:50Z",
+  "current": { /* MetricSample */ },
+  "history": [ /* MetricSample, oldest first */ ],
+  "interval_seconds": 10,
+  "history_size": 360
+}
+```
+
+Query params:
+- `?since=<rfc3339>` truncates `history` to samples after the timestamp.
+- `?fields=cpu,mem` projects the response (cuts payload for the dashboard's compact charts; default = all).
+- 404 with `resource_not_found` if VM doesn't exist; 200 with `state: "stopped"` and frozen history if VM exists but is stopped.
+
+**Real-time stream (`GET /api/v1/vms/{id}/stats/stream`).** SSE, one frame per sample. Reuses the SSE machinery from 4.2.10. Frames carry the same `MetricSample` JSON. No replay needed (the REST history call provides initial backfill); on connect, the client sends the most recent `history` GET, then subscribes for new samples.
+
+**Chart library choice.** uPlot (~45 KB gzipped) is preferred over recharts (~95 KB) for time-series — its canvas renderer handles 360+ points smoothly and re-renders at every new sample without React reconciliation pressure. Wrap in a `<MetricChart>` component to keep the dependency local.
+
+**Privacy/perf considerations.**
+- `balloon.available` requires the QEMU guest agent. When absent, return `null` rather than estimating; surface an info badge in the UI ("Install qemu-guest-agent for memory pressure metrics").
+- VM owners should not see other VMs' metrics — once 3.1.5 RBAC lands, `/stats` enforces VM ownership. v1 (single-tenant API key) skips this check.
+- Sampling adds ~5ms per call regardless of VM count (bulk API) but holds the libvirt connection mutex briefly. Don't go below 5s sampling without measuring under load.
+
+#### 4.1.1 Task list
 
 | # | Task | Effort | Notes |
 |---|------|--------|-------|
-| 4.1.1 | Collect CPU, memory, disk, and network I/O stats from libvirt `DomainStats` API | M | Poll on interval (e.g., 10s), store in ring buffer per VM |
-| 4.1.2 | Add `GET /api/v1/vms/{id}/stats` endpoint: current + recent history | M | Return time-series array |
-| 4.1.3 | Add real-time resource graphs to VMDetail page (CPU/RAM/disk/network) | L | Use lightweight chart library (e.g., recharts or uPlot) |
-| 4.1.4 | Add host-level stats to dashboard: total CPU/RAM usage, disk space, VM count | M | ✅ Done — added `GET /api/v1/host/stats` for host CPU/RAM/disk utilization + VM count and surfaced it in the dashboard cards |
-| 4.1.5 | Add `vmsmith vm stats <id>` CLI command | S | |
+| 4.1.1 | Define `pkg/types/metrics.go` (`MetricSample`, `VMStatsSnapshot`) with all fields as pointers (nil = unavailable) | S | |
+| 4.1.2 | Create `internal/metrics/` package: sampler goroutine using `Connect.GetAllDomainStats`, per-VM ring buffer, counter→rate conversion with reset detection, sweep for stopped/deleted VMs. Unit tests with a mock libvirt-stats provider | L | Mock provider feeds synthetic counter sequences (normal, reset, jump, stale) to validate rate math |
+| 4.1.3 | Wire `metrics.Manager` into daemon startup; honor `daemon.metrics.enabled` (default true), `sample_interval` (10s), `history_size` (360) config fields. Document in `vmsmith.yaml.example` | S | Disable cleanly if libvirt is unavailable in tests |
+| 4.1.4 | `GET /api/v1/vms/{id}/stats` endpoint with `?since=` and `?fields=` query params; 200/404/410-on-deleted contract above | M | Add to `handlers_vm.go`; integration tests with seeded mock samples |
+| 4.1.5 | `GET /api/v1/vms/{id}/stats/stream` SSE endpoint reusing 4.2.10's SSE helper. Frame per sample. Closes on VM delete or daemon shutdown | M | Depends on 4.2.10. If 4.2 is slipping, ship 4.1.4 and a polling frontend first |
+| 4.1.6 | Prometheus `/metrics` endpoint exposing per-VM `vmsmith_vm_cpu_percent{vm="..."}` etc. plus host-level metrics. Allow scraping behind same auth or unauthenticated on a dedicated `daemon.metrics.scrape_listen` (e.g., `127.0.0.1:9101`) so Prometheus doesn't need an API key. Add deployment notes | M | Use `prometheus/client_golang`. Solves the durable-history problem without us building a TSDB |
+| 4.1.7 | Frontend: `web/src/components/MetricChart.jsx` using uPlot; `web/src/hooks/useVMStats.js` doing initial REST fetch + SSE subscription with polling fallback. Add 4 charts (CPU, RAM, disk, net) to VMDetail under a new "Metrics" tab | L | Charts reuse the same hook; pass a `field` prop |
+| 4.1.8 | Frontend: dashboard "top 5 VMs by CPU" widget driven by an aggregator endpoint `GET /api/v1/vms/stats/top?metric=cpu&limit=5` (computed from latest sample per ring; no extra storage) | S | |
+| 4.1.9 | CLI: `vmsmith vm stats <id> [--watch] [--fields cpu,mem]` — one-shot prints latest sample + 5-min averages; `--watch` streams via SSE and refreshes a tabular UI in place | S | Use `tablewriter` or simple `\033[2J` redraw; document the env var to disable colors |
+| 4.1.10 | Tests: unit (rate math edge cases incl. counter reset / overflow / stopped VM), integration (`/stats` endpoint with stopped/missing/running VMs, SSE stream replay-not-supported behavior, Prometheus scrape format), E2E (real VM under load shows non-zero CPU + non-zero net during apt install) | L | E2E uses `stress-ng` over SSH to drive CPU; verify the chart hook reflects it within 30s |
+| 4.1.11 | Docs: `docs/ARCHITECTURE.md` "Metrics" subsection (sampling, ring buffer, rate math, deferred persistence, Prometheus integration). Add to `docs/PRODUCTION_DEPLOYMENT.md` an example `prometheus.yml` scrape config | S | |
+
+The original 4.1.4 (host-level stats on dashboard) is already done and remains in place above the table for context — kept here as the pre-existing baseline.
+
+#### 4.1.2 Open architectural questions
+
+1. **Guest-agent dependency.** RAM pressure metrics depend on `qemu-guest-agent` running inside the guest. Should the create flow install + enable it via cloud-init by default? Trade-off: smaller base image vs richer metrics out of the box. Recommendation: default-on for VMs created via vmsmith; document the cloud-init line so operators can opt out for embedded distros.
+2. **Disaggregating disk/net metrics.** Right now we sum across all disks and interfaces. Once multi-NIC VMs exist (already supported), the chart loses signal. Add `?disaggregate=true` returning a per-device breakdown later.
+3. **High-frequency sampling for short-lived spikes.** A 10s sample misses 1s CPU spikes. Adding adaptive sampling (5s when CPU > 80%, 10s otherwise) is tempting but doubles complexity. Defer; document as a known limitation.
+4. **Bulk-stats RPC failure modes.** `GetAllDomainStats` can return partial results (some domains missing) when libvirt is under load. Detect and log when the returned VM count is less than the running-VM count, but don't gap-fill — let the chart show the gap.
+
+#### 4.1.3 Dependencies
+
+- **4.2 (events)** — required for 4.1.5 (SSE stream) and the `metrics.sample`-as-event flow. Without 4.2, fall back to polling for the frontend.
+- **3.1 (auth)** — required before exposing `/stats` outside localhost; per-VM RBAC waits for 3.1.5.
+- **5.5 (multi-host)** — Prometheus labels should include a `host` label from day one (`vmsmith_vm_cpu_percent{vm="...",host="..."}`) so a future multi-host setup can shard by host without renaming series.
 
 ### 4.2 Event System & Notifications
 
-No way to know when a VM crashes, completes creation, or changes state.
+No way to know when a VM crashes, completes creation, or changes state. The work in this section is the foundation for several downstream features (audit log, dashboards without polling, schedules in 5.2, future alerting).
+
+**Status (2026-04-28):** Partially started. `internal/vm/events.go` already registers a `DomainEventLifecycleRegister` callback, runs the libvirt default event loop, and propagates state into the `vms` bbolt bucket. The events themselves are **not** persisted, queried, or streamed — every consumer below has to be built. The libvirt callback is the only producer wired up; API handlers and daemon code do not yet emit events.
+
+#### 4.2.0 Architectural overview
+
+**Event taxonomy.** Three sources, all flowing through one in-process bus:
+
+| Source | Origin | Examples |
+|---|---|---|
+| `libvirt` | `DomainEventLifecycleRegister` callback (already wired) | `vm.started`, `vm.stopped`, `vm.crashed`, `vm.shutdown`, `vm.suspended` |
+| `app` | API/CLI mutating handlers, post-success | `vm.created`, `vm.cloned`, `vm.updated`, `vm.deleted`, `snapshot.created`, `snapshot.restored`, `image.uploaded`, `port_forward.added` |
+| `system` | Daemon internals | `daemon.started`, `daemon.shutdown`, `quota.exceeded`, `dhcp.exhausted`, `webhook.delivery_failed` |
+
+A typed `Event` record (new `pkg/types/event.go`):
+
+```go
+type Event struct {
+    ID         string            `json:"id"`           // stringified uint64 today; opaque ordered ID for forward-compat with 5.5 multi-host
+    Type       string            `json:"type"`         // e.g. "vm.started"
+    Source     string            `json:"source"`       // "libvirt" | "app" | "system"
+    VMID       string            `json:"vm_id,omitempty"`
+    ResourceID string            `json:"resource_id,omitempty"` // generic (image/template/etc.)
+    Severity   string            `json:"severity"`     // "info" | "warn" | "error"
+    Message    string            `json:"message"`
+    Attributes map[string]string `json:"attributes,omitempty"`
+    OccurredAt time.Time         `json:"occurred_at"`
+    Actor      string            `json:"actor,omitempty"` // API key alias or "system"
+}
+```
+
+Outbound payloads include a top-level `schema_version: 1` so downstream consumers can detect breaking changes without sniffing fields.
+
+**In-process event bus (new `internal/events/` package).**
+- Single `EventBus` shared across the daemon. Producers call `Publish(ctx, Event)`; subscribers register via `Subscribe(filter) (<-chan Event, cancel func())`.
+- Implementation: a fan-out broker with a slice of buffered subscriber channels (default 64) under `sync.RWMutex`. Slow subscribers are **dropped, not blocked** — losing a webhook target must never stall the libvirt event loop. Drops emit one `system`-source `subscriber_lagged` event with the subscriber name, throttled to 1/min.
+- ID assignment is centralized in the bus using a monotonically increasing `uint64` counter, persisted in a `events_meta` bucket as 8-byte big-endian. On startup the counter is recovered as `max(persisted_next_id, last_event_id_in_bucket+1)`; persistence is best-effort, idempotent on replay.
+- A single goroutine inside the bus consumes the publish channel and (1) writes to bbolt, (2) fans out to live subscribers. This guarantees the persisted log and SSE replay see events in the same order.
+
+**Persistence (bbolt).**
+- New bucket `events`, key = 8-byte big-endian `uint64` ID, value = JSON `Event`. Big-endian keys make BoltDB cursor iteration return events in chronological order — what every consumer wants for free.
+- `events_meta` bucket stores `next_id` and the timestamp of the last retention sweep.
+- No secondary indexes at v1: `?vm_id=` / `?type=` filters scan reverse-chronologically and short-circuit on `limit`. With caps below this is sub-millisecond. Add an `events_by_vm` (`{vm_id}/{id_be}` → empty) index later if profiling shows scan cost.
+- Retention loop runs every 60s in a single Update tx: drop oldest until `count ≤ daemon.events.max_records` (default 50_000) and `age ≤ daemon.events.max_age` (default 720h / 30 days). Retention deletes are batched, capped at 5000/sweep so a backlog can't stall the writer.
+
+**SSE protocol (`GET /api/v1/events/stream`).**
+- Headers: `Content-Type: text/event-stream`, `Cache-Control: no-cache, no-transform`, `Connection: keep-alive`, `X-Accel-Buffering: no` (defeats nginx response buffering).
+- Frame format: `id: <event_id>\nevent: <type>\ndata: <json>\n\n`. Always emit the JSON event body so frontends can ignore `event:` if they want a single handler.
+- **Replay.** Honor `Last-Event-ID` request header; fall back to `?since=<id>` query param (browser `EventSource` cannot set custom headers). Replay is capped at `daemon.events.sse_replay_limit` (default 1000). If the client is further behind, return `410 Gone` with code `event_stream_replay_window_exceeded` so the client falls back to paginated REST.
+- **Heartbeat.** 30s `: keepalive\n\n` comment frames defeat idle proxies and let the server detect dead connections via write failure.
+- **Backpressure.** Per-connection buffered channel (64). On overflow: send a final `event: stream_lagged\n` frame and close. Silently dropping events is worse than terminating — clients can reconnect with the latest received `id`.
+- **Lifecycle.** Track active connections in the SSE hub; expose count in `GET /api/v1/host/stats`. On `BeginShutdown`, send `event: shutdown` to all active connections and close.
+- **Auth.** Default path uses the same `Authorization: Bearer` middleware as the rest of `/api/v1/*`. EventSource cannot send custom headers, so accept `?api_key=` as a same-origin fallback for the embedded GUI; rate-limit it, never log it, and document the tradeoff. Long-term: short-lived signed cookie issued at login (deferred to 3.1.5).
+
+**Webhook delivery (new `internal/webhooks/`).**
+- Configured per webhook (new `webhooks` bucket): `id`, `url`, `secret`, `event_types` (glob list, default `*`), `severity_floor`, `enabled`.
+- Dispatcher subscribes to the bus, matches each event against enabled webhooks, and queues delivery in a bounded in-memory queue (1000). Overflow drops oldest and emits `webhook.delivery_failed` (system) with reason `queue_overflow`.
+- **Retry policy.** 5 attempts with exponential backoff + jitter: 1s, 5s, 30s, 2m, 10m. Final failure emits a `webhook.delivery_failed` system event with the receiver's last status code and error string — visible in the events stream itself, so operators don't need a separate UI to debug.
+- **Signing.** `X-VMSmith-Signature: sha256=<hex>` over the raw request body using the webhook secret (HMAC-SHA256). Also send `X-VMSmith-Event-Id`, `X-VMSmith-Event-Type`, `X-VMSmith-Timestamp` (Unix seconds) so receivers can route quickly and reject replays.
+- **SSRF protection.** `daemon.webhooks.allowed_hosts` allowlist (domain or CIDR). Default deny-list always applied: `127.0.0.0/8`, `169.254.0.0/16`, `::1`, `fc00::/7`, `fe80::/10`, and the `192.168.100.0/24` VM NAT range. DNS resolution happens once per attempt and the resolved IP is checked against the deny-list before connecting (prevents DNS-rebinding round-trips).
+- **Concurrency.** 4-worker pool. `http.Client` with 10s timeout; connections are not reused across webhooks (per-target `Transport`) to keep one slow receiver from starving the rest.
+
+**Failure modes.**
+| Failure | Behavior |
+|---|---|
+| Bolt write error in persister | log at `error`, increment `events_dropped_total`, do **not** block the producer. The libvirt event loop must keep running. |
+| Subscriber channel full (slow consumer) | drop event for that subscriber only; emit throttled `subscriber_lagged` |
+| SSE replay window exceeded | 410 with `event_stream_replay_window_exceeded`; client falls back to REST pagination |
+| Webhook receiver down | retry per policy; persist final failure as a `webhook.delivery_failed` event |
+| Daemon crash mid-publish | producer holds a copy until `Publish` returns; on graceful shutdown, drain the publish channel within `daemon.events.shutdown_timeout` (default 5s) before closing the store |
+
+#### 4.2.1 Task list
 
 | # | Task | Effort | Notes |
 |---|------|--------|-------|
-| 4.2.1 | Subscribe to libvirt domain lifecycle events (start, stop, crash, reboot) | M | ✅ Done — `internal/vm/events.go` subscribes to libvirt events via `ConnectDomainEventLifecycleRegister` and updates store |
-| 4.2.2 | Store events in new bbolt bucket with timestamp, VM ID, event type | S | ✅ Done — events persist in the `events` bucket with store coverage in `internal/store/bolt_test.go` |
-| 4.2.3 | Add `GET /api/v1/events` endpoint with optional `?vm_id=` and `?since=` filters | M | ✅ Done — `handlers_events.go` implements filtering, descending sort, and pagination |
-| 4.2.4 | Add Server-Sent Events (SSE) stream at `GET /api/v1/events/stream` | M | Real-time push instead of polling |
-| 4.2.5 | Add event timeline to VMDetail page | M | |
-| 4.2.6 | (Future) Webhook support: POST to configured URL on configurable events | L | |
+| 4.2.1 | Subscribe to libvirt domain lifecycle events | M | ✅ Done — `internal/vm/events.go` registers the callback and propagates state to the `vms` bucket. **Does not yet emit events to a bus**; 4.2.4 wires that in |
+| 4.2.2 | Extend `pkg/types/event.go` to the full record above (`Source`, `Severity`, `Attributes`, `Actor`, `OccurredAt`, `ResourceID`) and add a top-level `schema_version` constant for outbound payloads | S | Partially done — main shipped a minimal `Event{ID, VMID, Type, Message, CreatedAt}` (`pkg/types/event.go` from PR #135). Field additions are additive; preserve existing JSON tags |
+| 4.2.3 | Create `internal/events/` package: `EventBus` with `Publish`/`Subscribe`/`Close`, ring-buffered fan-out, slow-subscriber drop with throttled `subscriber_lagged` warning, monotonic `uint64` ID assignment | M | Unit-test fan-out, drop, ID monotonicity, concurrent `Publish` |
+| 4.2.4 | Refactor `internal/vm/events.go` to call `bus.Publish` for each lifecycle callback; move state mutation into a separate `persistVMState` consumer subscribed to `libvirt` events. Removes the direct `store.PutVM` call from the libvirt goroutine. | S | Keeps the existing behavior but makes the event bus the single source of truth |
+| 4.2.5 | Promote the existing `events` bucket to the indexed scheme: add `events_meta` (next_id), key events by big-endian `uint64` ID, expose `Store.ListEvents(filter, limit)`, `Store.EventByID(id)`, `Store.PruneEvents(maxRecords, maxAge)` | M | Partially done — `BucketEvents` exists with basic CRUD and a flat `ListEvents()` (`internal/store/bolt.go`, models.go from PR #135). This task adds ordered keys + filter-aware listing + pruning |
+| 4.2.6 | Emit `app`-source events from API handlers: VM create / clone / update / delete, snapshot create / restore / delete, image upload / delete, port forward add / remove. Provide an `events.PublishAppEvent(ctx, type, vmID, attrs)` helper that pulls the actor from the auth middleware context | M | Touches every mutating handler. Single helper avoids drift |
+| 4.2.7 | Emit `system`-source events for daemon start / shutdown, quota exceeded, DHCP exhaustion, port-forward restore failure | S | One-line publishes alongside existing `logger.Info`/`logger.Warn` calls |
+| 4.2.8 | Retention loop (every 60s) honoring `daemon.events.max_records` (default 50_000) and `daemon.events.max_age` (default 720h); cap deletes per sweep at 5000; emit `system` event when retention drops events | S | Single Update tx; metric for deleted count |
+| 4.2.9 | Extend `GET /api/v1/events` with `?type=`, `?source=`, `?severity=`, `?until=<id>` filters (in addition to the existing `?vm_id=`, `?since=`, page / per_page), align replies to use `since`/`until` IDs alongside the current `since` timestamp, ensure same auth + rate-limit as other API routes | M | Partially done — basic listing with `vm_id`, `since` (RFC3339), pagination, `X-Total-Count`, and descending sort already shipped in `internal/api/handlers_events.go`. This task adds filter coverage and ID-cursor pagination |
+| 4.2.10 | `GET /api/v1/events/stream` SSE endpoint: `Last-Event-ID` header support, `?since=` query fallback, 30s heartbeat, `daemon.events.sse_replay_limit` (default 1000), 410 with `event_stream_replay_window_exceeded` on overflow, `?api_key=` query auth fallback for browser EventSource. New `internal/api/sse.go` helper for headers / heartbeat / `http.Flusher` plumbing. Track active connection count and surface it in `host_stats` | L | Test with `httptest` + a custom flushing recorder; verify replay, heartbeat cadence, 410 path, and clean shutdown |
+| 4.2.11 | Frontend: `web/src/hooks/useEventStream.js` — opens `EventSource`, handles reconnect with `Last-Event-ID`, falls back to polling on 410 / network error for 30s, exposes connection state. Replace polling on Dashboard and VMList with the hook; add a small "live" indicator | M | Reconnect uses exponential backoff; tests in `tests/web/` with mock SSE server |
+| 4.2.12 | Frontend: "Activity" tab on VMDetail showing reverse-chronological event timeline filtered by `vm_id`, infinite scroll via `until=<id>` | M | Reuses event JSON; no extra API |
+| 4.2.13 | Frontend: top-level "Activity" page with filter chips (type / severity / source) and date-range picker, deep links via query params | M | |
+| 4.2.14 | CLI: `vmsmith events list [--vm <id>] [--type <t>] [--source <s>] [--severity <sev>] [--since <duration|id>] [--limit <n>]` (one-shot REST query) and `vmsmith events follow [--vm <id>] [--type <t>]` (SSE, prints events as they arrive, exits on Ctrl-C) | M | Mirrors API filters; `--since 5m` accepts duration or numeric ID |
+| 4.2.15 | Webhook subsystem: `webhooks` bbolt bucket; `POST/GET/DELETE /api/v1/webhooks` endpoints; HMAC-SHA256 signing; exponential backoff with jitter (1s/5s/30s/2m/10m); bounded queue (1000) with `queue_overflow` system event; SSRF protection via `daemon.webhooks.allowed_hosts` allowlist plus default deny-list of loopback / link-local / metadata / VM-NAT ranges; DNS resolution checked against deny-list before connect | L | New `internal/webhooks/` package; emits `webhook.delivery_failed` on giving up so the events stream itself reflects delivery health |
+| 4.2.16 | Webhook UI: list / create / delete in Settings page; "send test event" button (synthesizes a `system.webhook_test` event for that webhook only); show last delivery status, response code, and most recent failure reason | M | |
+| 4.2.17 | Tests: unit (`EventBus` fan-out / slow-drop / ID monotonicity, Bolt persister round-trip, retention sweep, webhook signing + SSRF deny), integration (HTTP `/events` filtering + pagination, SSE replay + heartbeat + 410 + shutdown frame, webhook end-to-end with mock receiver covering retry + final failure event), E2E (start a real VM and assert `vm.started` arrives on the live SSE stream) | L | `httptest` SSE harness; mock HMAC verification example included so the test doubles as documentation |
+| 4.2.18 | Docs: new `docs/ARCHITECTURE.md` "Event System" section covering bus, persistence layout, SSE protocol (frame format + replay rules), webhook contract (payload shape + signature verification with a 6-line bash example) | S | Cross-link from CLAUDE.md and README |
+
+#### 4.2.2 Open architectural questions
+
+These are deliberately deferred — flag them in the PRs that touch them.
+
+1. **Pre-shutdown drain semantics.** Does `BeginShutdown` stop emitting `app` events (rejecting state-changing requests already returns 503) or only stop accepting new HTTP requests? Recommendation: keep emitting for in-flight requests, then close the bus after the libvirt connection is closed so terminal `vm.stopped`/`daemon.shutdown` events are recorded.
+2. **SSE auth for the embedded UI.** Once 3.1 auth is enabled, `EventSource` cannot send custom headers. The `?api_key=` fallback is acceptable for same-origin GUI but should be rate-limited and never written to the request log. Long-term: short-lived signed session cookie (move to 3.1.5).
+3. **Webhook payload stability.** Once webhooks ship, the outbound JSON is part of the public contract. Reserve the right to add fields, but never rename or remove. `schema_version: 1` from day one.
+4. **Multi-host (5.5) implications.** When events come from multiple hosts, IDs need either a central allocator or a per-host namespace (`{host_id}-{seq}`). Modeling `Event.ID` as a `string` from v1 keeps that option open even though v1 always emits stringified `uint64`.
+5. **Cross-cutting actor capture.** 4.2.6's `PublishAppEvent` helper assumes auth middleware has already populated a request-scoped context value. If auth is disabled (`daemon.auth.enabled: false`), `Actor` should be `"anonymous"` — not blank — so audit queries can distinguish "no auth configured" from "system-emitted".
+
+#### 4.2.3 Dependencies
+
+- **3.1 (auth)** — must be in place before exposing webhook config (admin-only) and before the SSE auth fallback design is finalized. The events system itself does not block on auth, but webhook UX does.
+- **3.4 (rate limiting)** — `?api_key=` SSE fallback should reuse the existing per-IP token bucket and add a separate stricter bucket for unauthenticated `/events/stream` connection attempts.
+- **4.1 (metrics)** — share the in-process retention pattern. The active-SSE-connection gauge belongs in `host_stats`. Consider unifying `events_dropped_total` and `webhook_*` counters once a metrics package exists.
+- **5.2 (schedules)** — `schedule.fired` and `schedule.failed` are `app`-source events; design 4.2.6's helper to be schedule-friendly (accept a synthetic actor like `"scheduler"`).
 
 ### 4.3 OpenAPI / Swagger Spec
 
@@ -212,27 +419,216 @@ Larger features for power users and advanced use cases.
 
 ### 5.1 VNC Console Access
 
-VNC is already configured in domain XML but not exposed. This would allow browser-based console access.
+VNC is already configured in domain XML (`internal/vm/domain.go:60` — `<graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1'/>`) but not exposed. The work below adds a browser-based console without ever opening the VNC port to the network.
+
+#### 5.1.0 Architectural overview
+
+**Threat model.** The VNC server is bound to `127.0.0.1` on the host. There is no VNC password by default and the RFB protocol is not encrypted. Two non-negotiable invariants:
+
+1. The VNC TCP port must **never** be reachable from outside the host. All access goes through the authenticated, TLS-terminated daemon.
+2. A console session must be authorized to the specific VM, time-limited, and revocable.
+
+**Proxy architecture.**
+- Frontend opens `WebSocket /api/v1/vms/{id}/console?ticket=<one-time-token>` from the browser.
+- Daemon's websocket handler validates the ticket, looks up the live VNC TCP port (`virsh domdisplay` or libvirt `Domain.GetXMLDesc` → parse `<graphics port='...'/>`), and pipes bytes between the websocket frame stream and `net.Dial("tcp", "127.0.0.1:<vnc_port>")`.
+- Subprotocol negotiation: `Sec-WebSocket-Protocol: binary` — noVNC sends and expects raw RFB bytes inside binary websocket frames.
+- Bidirectional copy uses two goroutines (`ws→tcp`, `tcp→ws`) joined on first close. Set both directions to a 30s idle write deadline; the noVNC client sends framebuffer-update requests on activity, so a long idle indicates a wedged connection.
+- The handler holds a `Conn` reference in a per-VM "active console session" map so admin-initiated VM stop / delete can `Close()` the websocket cleanly (`event: console.session_terminated`).
+
+**One-time ticket flow.** EventSource and WebSocket both have weak custom-header support in browsers, and embedding API keys in URLs leaks them into proxy logs. The flow:
+
+1. Client `POST /api/v1/vms/{id}/console/ticket` with normal `Authorization: Bearer` auth → response `{ "ticket": "...", "expires_at": "...", "websocket_url": "wss://.../api/v1/vms/{id}/console?ticket=..." }`.
+2. Tickets are 32 random bytes (base64url-encoded), single-use, valid for 60s, scoped to the VM ID and the issuing API key. Stored in an in-memory map (`map[string]ticket{vmID, expires, apiKey}`) under `sync.RWMutex` with a janitor goroutine sweeping every 30s.
+3. Websocket handler consumes the ticket on connect (delete-on-read), validates VM ID match, then upgrades. After upgrade, the ticket is gone — refresh requires a new POST.
+
+**VNC password handling (optional, per-VM).**
+- New `vnc_password` field on `types.VM` (write-only via API: accepted on create/update, redacted on read; persisted in bbolt as bcrypt-hashed for storage and reversibly encrypted for the libvirt domain XML using a daemon-level key from `daemon.console.password_key`).
+- When set, regenerate domain XML with `<graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' passwd='<plain>'/>` and apply on next start.
+- The proxy still requires the ticket. The VNC password is a defense-in-depth layer for the rare case where the daemon socket is mis-bound.
+- The proxy does **not** transparently inject the password — the noVNC client prompts the user. (Auto-injection would defeat the second factor.)
+
+**Frontend integration.**
+- Bundle noVNC's `core/rfb.js` (~200KB minified) under `web/src/vendor/novnc/`. Pin a specific version; do not load from CDN.
+- New `web/src/pages/VMConsole.jsx` opens at `/vms/{id}/console`. On mount: POST for ticket → instantiate `RFB(canvas, websocketUrl)` → handle `disconnect`/`credentialsrequired`/`securityfailure` events.
+- Keyboard capture: noVNC handles this; toggle full-screen with a button (calls `rfb.focus()`); add a "send Ctrl-Alt-Del" button (`rfb.sendCtrlAltDel()`).
+- Reconnect on transient failure: re-POST for a new ticket and re-instantiate `RFB`. After 3 failures within 30s, surface an error and stop auto-retrying.
+
+**Serial console alternative.** `<console type='pty'>` already exists in domain XML. libvirt exposes the pty path via `Domain.OpenConsole()` which returns a libvirt `Stream`. Wrap that stream in a websocket the same way as VNC, but serve as `text` subprotocol (UTF-8). Frontend uses `xterm.js` (~150KB). The same ticket flow applies; tickets carry an `intent: "vnc" | "serial"` field so a single-purpose ticket can't be redirected.
+
+**Resource limits.**
+- `daemon.console.max_concurrent_sessions` (default 8): global cap to prevent a leak of file descriptors and goroutines. Excess returns HTTP 429 `console_limit_reached`.
+- `daemon.console.max_session_seconds` (default 3600): hard idle timeout. After expiry the daemon sends a websocket close frame.
+- `daemon.console.idle_timeout_seconds` (default 600): closes the session after 10 min of zero traffic in either direction.
+
+**Observability.** Each session emits three `app`-source events (depends on 4.2): `console.session_started`, `console.session_ended` (with reason: `client_close` / `server_idle` / `vm_stopped` / `daemon_shutdown` / `error`), and `console.session_terminated` for admin-revoked sessions. Active session count is reported in `host_stats`.
+
+**Security checklist (must hold for v1).**
+- [ ] Ticket endpoint requires `Authorization: Bearer`.
+- [ ] Ticket is single-use, ≤60s TTL, scoped to VM ID + API key.
+- [ ] Websocket handler rejects requests without a valid ticket with HTTP 401.
+- [ ] VNC port stays bound to `127.0.0.1` — verified by an integration test that asserts external connect refuses.
+- [ ] No ticket appears in any access log (the middleware redacts `?ticket=`).
+- [ ] Sessions are forcibly closed on VM stop, VM delete, daemon shutdown, and API-key revocation.
+- [ ] `wss://` is required when TLS is configured (`ws://` rejected with 403 to avoid mixed-content downgrade).
+
+#### 5.1.1 Task list
 
 | # | Task | Effort | Notes |
 |---|------|--------|-------|
-| 5.1.1 | Add websocket proxy endpoint `GET /api/v1/vms/{id}/console` | L | Proxy TCP connection to VNC socket via websocket (noVNC protocol) |
-| 5.1.2 | Embed noVNC client in frontend, add "Console" tab to VMDetail | L | noVNC is ~200KB, MIT-licensed |
-| 5.1.3 | Add VNC password support (per-VM, stored in bbolt) | M | |
-| 5.1.4 | Add serial console alternative for headless VMs | M | `virsh console` equivalent via websocket |
+| 5.1.1 | Add `internal/console/` package: ticket store (in-memory map + janitor), `IssueTicket(vmID, apiKey)`, `ConsumeTicket(token, vmID) (apiKey, error)`. Unit tests for single-use, expiry, VM-scope mismatch | M | Pure Go; no libvirt deps |
+| 5.1.2 | Add `POST /api/v1/vms/{id}/console/ticket` endpoint returning `{ticket, expires_at, websocket_url}`. Reuse `Authorization: Bearer` middleware. Validate VM exists and is in `running` state (refuse `stopped` with 409 `vm_not_running`) | S | Middleware order: auth → rate-limit → handler |
+| 5.1.3 | Add `vm.Manager.GetConsoleEndpoint(ctx, id, intent) (host string, port int, err error)`: parses domain XML for `<graphics>` (VNC) or returns the pty path for serial. Implement on `LibvirtManager` and `MockManager` | M | Mock returns a synthetic listener for tests |
+| 5.1.4 | Add `GET /api/v1/vms/{id}/console` websocket endpoint: validate ticket, dial VNC TCP socket, bidirectional copy with idle deadlines, register session in active map. Use `gorilla/websocket` (already pulled in indirectly? — confirm during 5.1.1) or `nhooyr.io/websocket`. Subprotocol `binary` | L | Handle: client close, server close, dial failure (502 `console_unreachable`), TLS-mismatch (403 `mixed_content_blocked`) |
+| 5.1.5 | Wire active-session map into `vm.Manager.Stop`/`Delete` so admin actions force-close in-flight sessions. Emit `console.session_terminated` (depends on 4.2) | S | |
+| 5.1.6 | Add daemon config: `daemon.console.max_concurrent_sessions` (8), `daemon.console.max_session_seconds` (3600), `daemon.console.idle_timeout_seconds` (600), `daemon.console.password_key` (random base64 secret). Document in `vmsmith.yaml.example` | S | `password_key` empty disables per-VM VNC passwords |
+| 5.1.7 | Vendor noVNC under `web/src/vendor/novnc/` (pinned version, license header preserved). Add `web/src/pages/VMConsole.jsx` with ticket fetch, RFB instantiation, Ctrl-Alt-Del button, fullscreen toggle, status overlay | L | Add to router as `/vms/:id/console`; "Console" button on VMDetail opens in a new tab to give a clean keyboard capture surface |
+| 5.1.8 | Add VNC password support: `vnc_password` field on `VMSpec`/`VMUpdateSpec`, redact-on-read in API responses, persist as bcrypt hash + reversible-encrypted blob (AES-GCM with `daemon.console.password_key`). Regenerate domain XML on next start with `passwd='...'`. Add unit tests for round-trip and redaction | M | Reject password on update if VM is running and require restart message |
+| 5.1.9 | Serial console (`?intent=serial`): `vm.Manager.OpenSerialConsole(ctx, id) (io.ReadWriteCloser, error)` wrapping `Domain.OpenConsole`. Websocket handler uses `text` subprotocol. Bundle `xterm.js` and add a "Serial" tab next to "VNC" on the VMConsole page | M | Tickets carry `intent`; ticket for VNC cannot open serial and vice versa |
+| 5.1.10 | Redact `?ticket=` from request middleware logs (extend the existing logging middleware to scrub the query param). Add a unit test asserting the ticket never appears in captured log output | S | |
+| 5.1.11 | Tests: unit (ticket store concurrency + expiry, password encryption round-trip, redaction), integration (ticket → websocket happy path with a fake VNC echo server, ticket reuse rejected, expired ticket rejected, VM stop forces close, idle timeout), Playwright (open console page, see canvas mount, send Ctrl-Alt-Del) | L | Use `httptest.NewServer` + `gorilla/websocket` test helpers |
+| 5.1.12 | Docs: new section in `docs/ARCHITECTURE.md` covering proxy design, ticket flow, security checklist; add operator note in `docs/PRODUCTION_DEPLOYMENT.md` about firewalling the host's loopback (no action needed if iptables doesn't touch `lo`) | S | |
+
+#### 5.1.2 Open architectural questions
+
+1. **Per-session vs per-VM concurrency.** Should two operators be able to view the same VM's console simultaneously? RFB supports it (read-only viewers); recommendation for v1: allow one read-write session and any number of read-only viewers, gated by `read_only: true` on the ticket. Defer to PR.
+2. **TLS termination behind reverse proxy.** When 3.2 (TLS) is satisfied via nginx/Caddy in front of the daemon, the websocket arrives as `ws://` on the loopback. The handler should trust `X-Forwarded-Proto` only when the source IP matches a configured `daemon.trusted_proxies` CIDR list. Co-design with 3.2.4 docs.
+3. **Clipboard sync.** noVNC supports clipboard via the `cuttext`/`bell` extensions. Cross-origin clipboard in browsers is restricted; document as "best effort" and disable by default behind `daemon.console.allow_clipboard`.
+4. **Audit detail.** Should keystrokes / mouse events be logged? Privacy implications are significant; recommendation: log only session boundaries (start/end + bytes-in/out totals), never payloads. Make this an explicit non-feature in docs.
+
+#### 5.1.3 Dependencies
+
+- **3.1 (auth)** — required. The ticket endpoint and websocket auth assume `Authorization: Bearer` middleware is in place. Without auth, anyone on the network gets full console access.
+- **3.2 (TLS)** — strongly recommended before exposing this beyond localhost. RFB inside `ws://` is plaintext.
+- **4.2 (events)** — `console.session_*` events are emitted via the events bus; if 4.2 hasn't shipped, fall back to `logger.Info` and revisit.
+- **3.4 (rate limiting)** — apply a stricter bucket on ticket issuance (e.g., 10/min per API key) to prevent enumeration of VM IDs through ticket POSTs.
 
 ### 5.2 Scheduled Operations
 
-Automate routine tasks like snapshots and backups.
+Automate routine tasks like snapshots, scheduled start/stop windows, and backups. The original task list glossed over several correctness questions (catch-up after restart, concurrent runs, missed window vs daylight-saving anomalies, action retries) that determine whether operators can actually trust the scheduler with production data.
+
+#### 5.2.0 Architectural overview
+
+**Core design.** A single in-process scheduler goroutine drives a list of `Schedule` records loaded from bbolt. Use `github.com/robfig/cron/v3` with the `WithSeconds` and `WithLocation` options for predictable spec parsing. The scheduler does **not** spawn a goroutine per schedule for execution — instead, every fire dispatches to a bounded worker pool so a stuck snapshot can't starve the rest.
+
+**`Schedule` record (`pkg/types/schedule.go`):**
+
+```go
+type Schedule struct {
+    ID             string         `json:"id"`             // sched-<unix-nano>
+    Name           string         `json:"name"`
+    VMID           string         `json:"vm_id"`          // empty = applies to all VMs (admin-only schedules)
+    TagSelector    []string       `json:"tag_selector,omitempty"` // alternative to VMID; OR-of-tags match
+    Action         string         `json:"action"`         // "snapshot" | "start" | "stop" | "restart"
+    CronSpec       string         `json:"cron_spec"`      // 6-field with seconds: "0 30 2 * * *"
+    Timezone       string         `json:"timezone"`       // IANA name; empty -> daemon's TZ
+    Enabled        bool           `json:"enabled"`
+    CatchUpPolicy  string         `json:"catch_up_policy"` // "skip" (default) | "run_once" | "run_all"
+    MaxConcurrent  int            `json:"max_concurrent"`  // default 1; serializes overlapping fires per-schedule
+    RetentionCount int            `json:"retention_count,omitempty"` // for snapshot action; 0 = use quota default
+    Params         map[string]any `json:"params,omitempty"` // action-specific (e.g., snapshot name template)
+    CreatedAt      time.Time      `json:"created_at"`
+    UpdatedAt      time.Time      `json:"updated_at"`
+    LastFiredAt    *time.Time     `json:"last_fired_at,omitempty"`
+    LastResult     string         `json:"last_result,omitempty"` // "success" | "error: ..."
+    NextFireAt     *time.Time     `json:"next_fire_at,omitempty"` // computed; cached for UI
+}
+```
+
+**Run records (`pkg/types/schedule_run.go`)** — separate bucket so the schedule definition stays small:
+
+```go
+type ScheduleRun struct {
+    ID         string    `json:"id"`           // run-<unix-nano>
+    ScheduleID string    `json:"schedule_id"`
+    VMID       string    `json:"vm_id"`        // resolved VM (tag selectors fan out)
+    StartedAt  time.Time `json:"started_at"`
+    FinishedAt time.Time `json:"finished_at,omitempty"`
+    Status     string    `json:"status"`       // "running" | "success" | "error" | "skipped"
+    Error      string    `json:"error,omitempty"`
+    SkipReason string    `json:"skip_reason,omitempty"` // "vm_not_found" | "vm_already_stopped" | "concurrent_run" | "catch_up_skipped"
+}
+```
+
+**bbolt layout:**
+- `schedules` — key = schedule ID, value = JSON `Schedule`.
+- `schedule_runs` — key = `{schedule_id}/{run_id_be}` (big-endian timestamp suffix). Compound key keeps a single forward cursor scan per-schedule history. Retention: per-schedule cap of `daemon.schedules.max_run_history` (default 200) trimmed in the same Update tx that writes a new run.
+- `schedule_meta` — key = `last_tick`, value = RFC3339 timestamp of the most recent successful tick (used for catch-up after a restart).
+
+**Catch-up semantics (the subtle part).** When the daemon restarts, some firings may have been missed. The scheduler reads `schedule_meta/last_tick` and computes which schedules would have fired between `last_tick` and `now()`. Three policies, configurable per schedule (`catch_up_policy`):
+
+| Policy | Behavior | Use case |
+|---|---|---|
+| `skip` | Ignore all missed fires. Resume normal scheduling. | Default. Idempotent actions where a missed window doesn't matter (e.g., periodic snapshot, the next one will replace it). |
+| `run_once` | If any fires were missed, run the action exactly once, then resume. | Backups: missing one is OK, but you want the system to know it's behind. |
+| `run_all` | Replay every missed fire in chronological order, sequentially. | Auditable schedules where every interval matters (rare; warn the operator if window > 24h). |
+
+`schedule_meta/last_tick` is updated every minute by the scheduler tick (whether or not any schedule fires). On startup, if it's missing, treat as `now()` (no catch-up — fresh install).
+
+**Daylight-saving and timezone handling.**
+- `Schedule.Timezone` is an IANA name (`America/New_York`). robfig/cron's `WithLocation` is per-scheduler, not per-entry, so we run **one cron instance per distinct timezone** and route each schedule to the right instance.
+- For ambiguous local times during DST transition (e.g., 02:30 on a fall-back day occurring twice), document that we use the wall-clock time once — robfig's behavior matches Go's `time.ParseInLocation`. Surface this in the schedule edit UI with a warning when the spec touches 02:00–03:00.
+
+**Concurrency control.**
+- Per-schedule: `MaxConcurrent` (default 1). If a fire arrives while the previous run is in progress, write a `ScheduleRun{Status: "skipped", SkipReason: "concurrent_run"}` and emit a `schedule.fire_skipped` event (depends on 4.2).
+- Global: `daemon.schedules.worker_pool_size` (default 4). The dispatcher queues fires onto the worker pool. Queue overflow drops with `skip_reason: "queue_full"` and emits a `system` event.
+
+**Action handlers.** Pluggable via a small `ScheduleActionFunc` registry:
+
+```go
+type ActionFunc func(ctx context.Context, vmID string, params map[string]any) error
+```
+
+v1 actions:
+
+| Action | Implementation |
+|---|---|
+| `snapshot` | `vm.Manager.CreateSnapshot(ctx, vmID, name)`. Snapshot name template defaults to `auto-{schedule_name}-{rfc3339}`. Honors `RetentionCount`: after creation, list snapshots whose names start with `auto-{schedule_name}-` and delete oldest until count ≤ retention. |
+| `start` | `vm.Manager.Start(ctx, vmID)`. Skip if already running with `skip_reason: "vm_already_running"`. |
+| `stop` | `vm.Manager.Stop(ctx, vmID)`. Skip if already stopped. |
+| `restart` | Stop then Start with a 30s wait between. Single run record. |
+
+**Tag-selector fan-out.** When `TagSelector` is set (and `VMID` is empty), the scheduler resolves the matching VM list at fire time — not at schedule-create time. Each matched VM gets its own `ScheduleRun` record. New VMs picked up automatically; deleted VMs simply produce zero runs.
+
+**Failure & retry.**
+- Per-action timeout from `daemon.schedules.action_timeout` (default 5m for snapshot, 30s for start/stop).
+- On transient error, retry up to `daemon.schedules.max_retries` (default 2) with 30s/2m backoff. Persistent error is recorded as `Status: "error"` with the last error string.
+- Retries do **not** create new `ScheduleRun` records — they update the existing one's `Error` field with each attempt's outcome (`attempt N: <err>; attempt N+1: <err>`).
+
+**Permissions (depends on 3.1).** Schedule CRUD requires the same auth as VM mutation. Once 3.1.5 (RBAC) lands, schedules are admin-only. v1 treats any authenticated request as authorized.
+
+**Observability.** Emits `schedule.created`, `schedule.deleted`, `schedule.updated`, `schedule.fired`, `schedule.fire_skipped`, `schedule.fire_succeeded`, `schedule.fire_failed`, `schedule.catch_up_replayed` (with N missed count). All `app`-source via 4.2's `PublishAppEvent` helper, with `Actor: "scheduler"` for fires.
+
+#### 5.2.1 Task list
 
 | # | Task | Effort | Notes |
 |---|------|--------|-------|
-| 5.2.1 | Add in-process cron scheduler (e.g., `robfig/cron`) | M | |
-| 5.2.2 | Define `Schedule` type: VM ID, action (snapshot, start, stop), cron expression, retention count | M | Store in bbolt bucket `schedules` |
-| 5.2.3 | Add CRUD endpoints for schedules | M | |
-| 5.2.4 | Add `vmsmith schedule create|list|delete` CLI commands | M | |
-| 5.2.5 | Add schedule management UI to VMDetail page | M | |
-| 5.2.6 | Implement snapshot retention: auto-delete oldest when count exceeds limit | S | ✅ Done — `daemon.quotas.max_snapshots_per_vm` auto-deletes the oldest snapshots to maintain limits |
+| 5.2.1 | Define `pkg/types/schedule.go` (`Schedule`) and `pkg/types/schedule_run.go` (`ScheduleRun`) per the schemas above | S | Pure types |
+| 5.2.2 | Add `schedules`, `schedule_runs`, `schedule_meta` bbolt buckets; `Store.{Put,Get,List,Delete}Schedule`, `Store.AppendRun(scheduleID, run)` (with retention trim in the same tx), `Store.ListRuns(scheduleID, limit)`, `Store.GetLastTick`/`SetLastTick` | M | `schedule_runs` keys are `{schedule_id}/{ts_be}` for fast per-schedule scans |
+| 5.2.3 | Create `internal/scheduler/` package: per-timezone `cron.Cron` instances, schedule registration/deregistration on CRUD, bounded worker pool, action registry. Unit tests for: spec parsing, timezone routing, max-concurrent skip, queue overflow | L | Use `robfig/cron/v3` with `WithSeconds` |
+| 5.2.4 | Implement catch-up logic on daemon startup: compare `last_tick` to `now()`, fire each schedule per its `catch_up_policy`. Tick the meta key every 60s thereafter | M | Cap `run_all` replay at 100 missed fires per schedule with a warning log to prevent storms |
+| 5.2.5 | Action registry with `snapshot`, `start`, `stop`, `restart` handlers. Snapshot honors `RetentionCount` and uses a name template scoped to the schedule. Per-action timeout + retry with backoff | M | Reject actions on non-existent/deleted VMs with `skip_reason: "vm_not_found"` |
+| 5.2.6 | Tag-selector resolution at fire time: query `Store.ListVMs` filtered by tag set; fan out to one `ScheduleRun` per matched VM, all queued onto the same worker pool | S | |
+| 5.2.7 | API: `POST /api/v1/schedules`, `GET /api/v1/schedules` (with `?vm_id=`, `?action=`, `?enabled=`), `GET /api/v1/schedules/{id}`, `PATCH /api/v1/schedules/{id}` (toggle enabled, update spec/retention), `DELETE /api/v1/schedules/{id}`, `GET /api/v1/schedules/{id}/runs` (paginated, reverse-chronological), `POST /api/v1/schedules/{id}/run-now` (synthesize a manual fire, recorded as `Actor: "<api-key-alias>"`) | M | Validate cron spec on create/update; reject invalid timezone with `invalid_timezone` |
+| 5.2.8 | CLI: `vmsmith schedule create --vm <id|--tag <t>> --action <a> --cron "<spec>" --timezone <tz> --retention <n> --catch-up <skip|run_once|run_all>`, `schedule list [--vm <id>]`, `schedule show <id>` (definition + last 20 runs), `schedule edit <id>` (PATCH), `schedule delete <id>`, `schedule run-now <id>` | M | Cron spec validated client-side via `robfig/cron` parser; surface `next_fire_at` in `list` output |
+| 5.2.9 | Frontend: `web/src/pages/Schedules.jsx` listing all schedules with enabled toggle, next-fire timestamp, last-result chip, "Run now" button. `web/src/components/ScheduleForm.jsx` for create/edit with cron-spec helper (preset chips: hourly, daily 02:00, weekly Sunday) | M | Plus a "Recent runs" expander on each row showing the last 5 runs |
+| 5.2.10 | Frontend: schedule section on VMDetail page showing schedules whose `vm_id == this.id` or whose tag selector matches this VM's tags. "Add schedule" opens the form pre-filled with this VM | S | |
+| 5.2.11 | Tests: unit (timezone routing across DST transitions using a fake clock, catch-up policies, max-concurrent skip, retention trim under concurrent appends, action retry/backoff), integration (CRUD endpoints, run-now synthesis, run history pagination), E2E (real schedule fires a snapshot on a real VM and the snapshot appears) | L | Use `clockwork.NewFakeClock` for time-travel; `cron.WithChain(cron.SkipIfStillRunning(...))` not enough — we need our own per-schedule mutex for clearer skip reasons |
+| 5.2.12 | Docs: new `docs/SCHEDULES.md` covering cron-spec syntax (note the 6-field with-seconds form), timezone/DST rules, catch-up policies with worked examples, retention semantics. Cross-link from CLAUDE.md | S | |
+| 5.2.13 | (Already done) Snapshot retention auto-delete | S | ✅ Done — `daemon.quotas.max_snapshots_per_vm` auto-deletes the oldest snapshots. The scheduler's `RetentionCount` is independent and scoped to *auto-named* snapshots from the same schedule, so manual snapshots are not affected |
+
+#### 5.2.2 Open architectural questions
+
+1. **Distributed schedules (future 5.5).** When multi-host lands, two daemons must not both fire the same schedule. Either elect a leader (use bbolt-on-shared-storage advisory locks, fragile), or namespace schedules per-host (`Schedule.HostID`). Recommendation: namespace per-host now (`HostID` empty = "this daemon's host"), defer leader election.
+2. **Idempotency keys for actions.** If `run_all` catch-up replays 30 missed `snapshot` fires after a 30-day outage, we'd create 30 snapshots and immediately retention-trim 28. Better: pass a `IdempotencyKey: "<schedule_id>:<scheduled_time_unix>"` to the action; snapshot handler skips if a snapshot with that key already exists. Defer to follow-up; v1 just trims.
+3. **Pause window override.** Operators want "don't run any schedule between 09:00–17:00 on weekdays" without editing every cron spec. Add `daemon.schedules.maintenance_window` later.
+4. **Cron-spec backward compat.** robfig/cron supports both 5-field and 6-field forms via constructor options. Pick one (6-field, seconds-required) and document it as the only accepted form to avoid 5-vs-6 confusion. Reject 5-field input with a clear error pointing to the 6-field equivalent.
+
+#### 5.2.3 Dependencies
+
+- **3.1 (auth)** — required before exposing schedule CRUD; "run-now" can fire arbitrary VM operations.
+- **4.2 (events)** — schedule lifecycle and fire events flow through the events bus. `Actor: "scheduler"` distinguishes them from operator-initiated runs in the audit log.
+- **3.5 (quotas)** — snapshot retention from 3.5.1 stacks with 5.2's per-schedule `RetentionCount`. Document that the lower of the two wins.
+- **5.5 (multi-host)** — informs the `HostID` namespacing question above. Add the field now even though it's unused in v1.
 
 ### 5.3 VM Import/Export (OVA/OVF)
 


### PR DESCRIPTION
Expand Phase 4.2 (Event System & Notifications) with the architectural
context the original 6-task outline lacked:

- Acknowledge the partial implementation already in internal/vm/events.go
  (libvirt lifecycle callback + state propagation) so the remaining work
  builds on what exists instead of duplicating it.
- Document event taxonomy (libvirt / app / system) and a concrete Event
  record with schema_version for forward compatibility.
- Specify the in-process EventBus contract: fan-out, slow-subscriber
  drop, single-writer ordering guarantee, monotonic uint64 IDs.
- Lay out the bbolt persistence layout (events + events_meta buckets,
  big-endian keys for chronological scans, retention sweep policy).
- Detail the SSE protocol: frame format, Last-Event-ID + ?since fallback,
  replay cap with 410, 30s heartbeat, per-connection backpressure,
  shutdown frame, EventSource ?api_key= auth fallback.
- Specify the webhook subsystem: HMAC-SHA256 signing, exponential
  backoff with jitter, bounded queue, SSRF allow/deny lists, per-target
  HTTP transport.
- Replace the 6 vague tasks with 18 concrete tasks, each with explicit
  acceptance criteria and effort estimates.
- Add open architectural questions and dependencies on 3.1/3.4/4.1/5.2.

https://claude.ai/code/session_01WhdR2i4suXsdUY7k3bpNSs