### PR TITLE
feat(vm): add VM restart action across manager, REST, CLI, and GUI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -420,6 +420,7 @@ POST   /vms/{id}/clone                 Clone VM (body: `{ "name": "clone-name" }
 PATCH  /vms/{id}                       Update VM resources (VMUpdateSpec: cpus, ram_mb, disk_gb, nat_static_ip, nat_gateway — zero/empty ignored; disk grow-only; IP change updates DHCP reservation + regenerates cloud-init ISO with new instance-id)
 POST   /vms/{id}/start                 Start VM
 POST   /vms/{id}/stop                  Stop VM
+POST   /vms/{id}/restart               Restart VM (graceful stop, 30s grace before forced destroy, then start)
 DELETE /vms/{id}                       Delete VM
 GET    /vms/{id}/snapshots             List snapshots
 POST   /vms/{id}/snapshots             Create snapshot

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -93,6 +93,25 @@ Operating on VMs one-at-a-time is tedious when managing many.
 | 2.3.2 | Add `vmsmith vm start --all`, `vmsmith vm stop --all`, with `--tag` filter | M | ✅ Done — CLI `vm start` / `vm stop` now accept `--all` with optional `--tag`, skip VMs already in the wrong state, and document/test the bulk lifecycle flow |
 | 2.3.3 | Add multi-select checkboxes + bulk action bar to VMList frontend page | M | ✅ Done — VMList now supports per-row selection, select-all for the current filtered view, and a bulk action bar that fans out start/stop/delete over existing per-VM endpoints with selection-aware skip messaging |
 
+#### 2.3.4 VM Restart action ✅
+
+`vm.Manager.Restart(ctx, id)` performs a graceful shutdown (30s grace before
+forced destroy) followed by a start. Surfaced everywhere the rest of the
+lifecycle is:
+
+- API: `POST /api/v1/vms/{vmID}/restart` (returns `{"status":"restarted"}`)
+- CLI: `vmsmith vm restart <id>`
+- GUI: "Restart" button next to Stop on VMDetail, only when the VM is running
+- Events: emits `vm.restart_requested` (`app` source) on success
+- Tests: unit (MockManager + happy-path / not-found / error-injection),
+  integration (`internal/api/api_test.go`: `TestRestartVM`,
+  `TestRestartVM_Error`), CLI (`TestCLI_VMRestart`,
+  `TestCLI_VMRestart_NotFound`), and Playwright mock GUI
+  (`restart running VM`)
+
+This is the manager-layer primitive that the future scheduler restart action
+(5.2.5) will reuse.
+
 ### 2.4 VM Templates
 
 Save and reuse VM configurations without re-specifying every parameter.
@@ -585,7 +604,7 @@ v1 actions:
 | `snapshot` | `vm.Manager.CreateSnapshot(ctx, vmID, name)`. Snapshot name template defaults to `auto-{schedule_name}-{rfc3339}`. Honors `RetentionCount`: after creation, list snapshots whose names start with `auto-{schedule_name}-` and delete oldest until count ≤ retention. |
 | `start` | `vm.Manager.Start(ctx, vmID)`. Skip if already running with `skip_reason: "vm_already_running"`. |
 | `stop` | `vm.Manager.Stop(ctx, vmID)`. Skip if already stopped. |
-| `restart` | Stop then Start with a 30s wait between. Single run record. |
+| `restart` | `vm.Manager.Restart(ctx, vmID)` — graceful `Shutdown()` (with a 30s grace period before `Destroy()` falls back) followed by `Create()`. Single run record. |
 
 **Tag-selector fan-out.** When `TagSelector` is set (and `VMID` is empty), the scheduler resolves the matching VM list at fire time — not at schedule-create time. Each matched VM gets its own `ScheduleRun` record. New VMs picked up automatically; deleted VMs simply produce zero runs.
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -230,6 +230,23 @@ paths:
           $ref: '#/components/responses/APIError'
         default:
           $ref: '#/components/responses/APIError'
+  /vms/{vmID}/restart:
+    post:
+      tags: [VMs]
+      summary: Restart a VM (graceful stop then start; or just start if stopped)
+      parameters:
+        - $ref: '#/components/parameters/VMID'
+      responses:
+        '200':
+          description: VM restarted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        '404':
+          $ref: '#/components/responses/APIError'
+        default:
+          $ref: '#/components/responses/APIError'
   /vms/{vmID}/clone:
     post:
       tags: [VMs]
@@ -1017,41 +1034,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BulkVMActionResult'
-    MetricSample:
-      type: object
-      required: [timestamp]
-      properties:
-        timestamp:
-          type: string
-          format: date-time
-        cpu_percent:
-          type: number
-          format: double
-          nullable: true
-        mem_used_mb:
-          type: integer
-          format: int64
-          nullable: true
-        mem_avail_mb:
-          type: integer
-          format: int64
-          nullable: true
-        disk_read_bps:
-          type: integer
-          format: int64
-          nullable: true
-        disk_write_bps:
-          type: integer
-          format: int64
-          nullable: true
-        net_rx_bps:
-          type: integer
-          format: int64
-          nullable: true
-        net_tx_bps:
-          type: integer
-          format: int64
-          nullable: true
     TopVMItem:
       type: object
       required: [vm_id, name, state, value]

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1695,6 +1695,44 @@ func TestDeleteVM_Error(t *testing.T) {
 	}
 }
 
+func TestRestartVM(t *testing.T) {
+	ts, mockMgr, cleanup := testServer(t)
+	defer cleanup()
+
+	mockMgr.SeedVM(&types.VM{ID: "vm-restart", Name: "rebooter", State: types.VMStateRunning})
+
+	resp, err := http.Post(ts.URL+"/api/v1/vms/vm-restart/restart", "application/json", nil)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	got, _ := mockMgr.Get(nil, "vm-restart")
+	if got.State != types.VMStateRunning {
+		t.Errorf("State = %q, want running", got.State)
+	}
+}
+
+func TestRestartVM_Error(t *testing.T) {
+	ts, mockMgr, cleanup := testServer(t)
+	defer cleanup()
+
+	mockMgr.SeedVM(&types.VM{ID: "vm-x", State: types.VMStateRunning})
+	mockMgr.RestartErr = types.ErrTest
+
+	resp, err := http.Post(ts.URL+"/api/v1/vms/vm-x/restart", "application/json", nil)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", resp.StatusCode)
+	}
+}
+
 func TestStartVM_Error(t *testing.T) {
 	ts, mockMgr, cleanup := testServer(t)
 	defer cleanup()

--- a/internal/api/handlers_vm.go
+++ b/internal/api/handlers_vm.go
@@ -345,6 +345,19 @@ func (s *Server) StopVM(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "stopped"})
 }
 
+// RestartVM handles POST /api/v1/vms/{vmID}/restart.  It performs a graceful
+// stop followed by a start; if the VM is already stopped it just starts.
+func (s *Server) RestartVM(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "vmID")
+	if err := s.vmManager.Restart(r.Context(), id); err != nil {
+		err = sanitizeManagerError(err)
+		writeAPIError(w, statusForAPIError(err, http.StatusInternalServerError), err)
+		return
+	}
+	s.publishAppEvent("vm.restart_requested", id, fmt.Sprintf("VM %q restart requested", id), nil)
+	writeJSON(w, http.StatusOK, map[string]string{"status": "restarted"})
+}
+
 // BulkVMAction handles POST /api/v1/vms/bulk.
 func (s *Server) BulkVMAction(w http.ResponseWriter, r *http.Request) {
 	var req bulkVMActionRequest

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -185,6 +185,7 @@ func (s *Server) setupRoutes(webHandler http.Handler) {
 				r.Delete("/", s.DeleteVM)
 				r.Post("/start", s.StartVM)
 				r.Post("/stop", s.StopVM)
+				r.Post("/restart", s.RestartVM)
 
 				// Snapshots
 				r.Route("/snapshots", func(r chi.Router) {

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -534,6 +534,36 @@ func TestCLI_VMStop_AllNoMatches(t *testing.T) {
 	}
 }
 
+func TestCLI_VMRestart(t *testing.T) {
+	mock, cleanup := withMockVM(t)
+	defer cleanup()
+
+	mock.SeedVM(&types.VM{ID: "vm-r", Name: "rebooter", State: types.VMStateRunning})
+
+	out, err := runCLI("vm", "restart", "vm-r")
+	if err != nil {
+		t.Fatalf("vm restart: %v", err)
+	}
+	if !strings.Contains(out, "vm-r") || !strings.Contains(out, "restarted") {
+		t.Errorf("expected VM id and 'restarted' in output, got: %q", out)
+	}
+
+	got, _ := mock.Get(nil, "vm-r")
+	if got.State != types.VMStateRunning {
+		t.Errorf("State = %q, want running", got.State)
+	}
+}
+
+func TestCLI_VMRestart_NotFound(t *testing.T) {
+	_, cleanup := withMockVM(t)
+	defer cleanup()
+
+	_, err := runCLI("vm", "restart", "nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent VM")
+	}
+}
+
 func TestCLI_VMDelete(t *testing.T) {
 	mock, cleanup := withMockVM(t)
 	defer cleanup()

--- a/internal/cli/vm.go
+++ b/internal/cli/vm.go
@@ -215,6 +215,30 @@ var vmStopCmd = &cobra.Command{
 	},
 }
 
+var vmRestartCmd = &cobra.Command{
+	Use:   "restart <id>",
+	Short: "Restart a VM (graceful stop, then start)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id := args[0]
+		logger.Info("cli", "vm restart", "id", id)
+		mgr, cleanup, err := newVMManager()
+		if err != nil {
+			logger.Error("cli", "vm restart: manager init failed", "error", err.Error())
+			return err
+		}
+		defer cleanup()
+
+		if err := mgr.Restart(cmd.Context(), id); err != nil {
+			logger.Error("cli", "vm restart failed", "id", id, "error", err.Error())
+			return err
+		}
+		logger.Info("cli", "vm action complete", "action", "restart", "id", id)
+		fmt.Printf("VM %s restarted\n", id)
+		return nil
+	},
+}
+
 var vmDeleteCmd = &cobra.Command{
 	Use:   "delete <id>",
 	Short: "Delete a VM and its resources",
@@ -849,6 +873,7 @@ Examples:
 	vmCmd.AddCommand(vmListCmd)
 	vmCmd.AddCommand(vmStartCmd)
 	vmCmd.AddCommand(vmStopCmd)
+	vmCmd.AddCommand(vmRestartCmd)
 	vmCmd.AddCommand(vmDeleteCmd)
 	vmCmd.AddCommand(vmInfoCmd)
 	vmCmd.AddCommand(vmStatsCmd)

--- a/internal/vm/lifecycle.go
+++ b/internal/vm/lifecycle.go
@@ -419,6 +419,70 @@ func (m *LibvirtManager) Stop(ctx context.Context, id string) error {
 	return m.store.PutVM(vm)
 }
 
+// Restart performs a graceful stop followed by a start.  When the VM is already
+// stopped, it just starts it.  The shutdown step falls back to a forced destroy
+// after restartShutdownTimeout so a stuck guest doesn't block the operation.
+func (m *LibvirtManager) Restart(ctx context.Context, id string) error {
+	vm, err := m.store.GetVM(id)
+	if err != nil {
+		return err
+	}
+
+	dom, err := m.conn.LookupDomainByName(vm.Name)
+	if err != nil {
+		return fmt.Errorf("looking up domain %s: %w", vm.Name, err)
+	}
+	defer dom.Free()
+
+	state, _, err := dom.GetState()
+	if err != nil {
+		return fmt.Errorf("getting domain state: %w", err)
+	}
+
+	if state == libvirt.DOMAIN_RUNNING {
+		if shutdownErr := dom.Shutdown(); shutdownErr != nil {
+			if destroyErr := dom.Destroy(); destroyErr != nil {
+				return fmt.Errorf("shutting down domain: %w (destroy fallback: %v)", shutdownErr, destroyErr)
+			}
+		} else if !waitForDomainShutoff(ctx, dom, restartShutdownTimeout) {
+			if destroyErr := dom.Destroy(); destroyErr != nil {
+				return fmt.Errorf("forcing shutdown after grace period: %w", destroyErr)
+			}
+		}
+	}
+
+	if err := dom.Create(); err != nil {
+		return fmt.Errorf("starting domain: %w", err)
+	}
+
+	vm.State = types.VMStateRunning
+	vm.UpdatedAt = time.Now()
+	return m.store.PutVM(vm)
+}
+
+// restartShutdownTimeout is the grace period given to a guest to react to ACPI
+// shutdown before Restart force-destroys it.  Kept short relative to libvirt's
+// default to avoid hanging an interactive `vmsmith vm restart` call.
+const restartShutdownTimeout = 30 * time.Second
+
+// waitForDomainShutoff polls dom.GetState until the domain reports SHUTOFF or
+// the deadline passes.  Returns true if the domain shut down within the window.
+func waitForDomainShutoff(ctx context.Context, dom *libvirt.Domain, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		state, _, err := dom.GetState()
+		if err == nil && state == libvirt.DOMAIN_SHUTOFF {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+	return false
+}
+
 // Delete removes a VM entirely: stops it, undefines the domain, removes disk files.
 func (m *LibvirtManager) Delete(ctx context.Context, id string) error {
 	vm, err := m.store.GetVM(id)

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -16,6 +16,7 @@ type Manager interface {
 	Update(ctx context.Context, id string, patch types.VMUpdateSpec) (*types.VM, error)
 	Start(ctx context.Context, id string) error
 	Stop(ctx context.Context, id string) error
+	Restart(ctx context.Context, id string) error
 	Delete(ctx context.Context, id string) error
 	Get(ctx context.Context, id string) (*types.VM, error)
 	List(ctx context.Context) ([]*types.VM, error)

--- a/internal/vm/mock_manager.go
+++ b/internal/vm/mock_manager.go
@@ -23,6 +23,7 @@ type MockManager struct {
 	UpdateErr          error
 	StartErr           error
 	StopErr            error
+	RestartErr         error
 	DeleteErr          error
 	GetErr             error
 	ListErr            error
@@ -201,6 +202,24 @@ func (m *MockManager) Stop(ctx context.Context, id string) error {
 	}
 
 	vm.State = types.VMStateStopped
+	vm.UpdatedAt = time.Now()
+	return nil
+}
+
+func (m *MockManager) Restart(ctx context.Context, id string) error {
+	if m.RestartErr != nil {
+		return m.RestartErr
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	vm, ok := m.vms[id]
+	if !ok {
+		return fmt.Errorf("vms/%s: not found", id)
+	}
+
+	vm.State = types.VMStateRunning
 	vm.UpdatedAt = time.Now()
 	return nil
 }

--- a/internal/vm/mock_manager_test.go
+++ b/internal/vm/mock_manager_test.go
@@ -150,6 +150,51 @@ func TestMockManager_Lifecycle(t *testing.T) {
 	}
 }
 
+func TestMockManager_Restart(t *testing.T) {
+	m := NewMockManager()
+	ctx := context.Background()
+
+	vm, _ := m.Create(ctx, types.VMSpec{Name: "rebooter"})
+	id := vm.ID
+
+	if err := m.Stop(ctx, id); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	if err := m.Restart(ctx, id); err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+	got, _ := m.Get(ctx, id)
+	if got.State != types.VMStateRunning {
+		t.Errorf("after restart: State = %q, want running", got.State)
+	}
+
+	// Restart-from-running should also leave it running.
+	if err := m.Restart(ctx, id); err != nil {
+		t.Fatalf("Restart from running: %v", err)
+	}
+	got, _ = m.Get(ctx, id)
+	if got.State != types.VMStateRunning {
+		t.Errorf("after second restart: State = %q, want running", got.State)
+	}
+}
+
+func TestMockManager_Restart_NotFound(t *testing.T) {
+	m := NewMockManager()
+	if err := m.Restart(context.Background(), "vm-missing"); err == nil {
+		t.Fatal("expected not-found error")
+	}
+}
+
+func TestMockManager_Restart_ErrorInjection(t *testing.T) {
+	m := NewMockManager()
+	vm, _ := m.Create(context.Background(), types.VMSpec{Name: "boom"})
+	m.RestartErr = fmt.Errorf("restart boom")
+	if err := m.Restart(context.Background(), vm.ID); err == nil || err.Error() != "restart boom" {
+		t.Fatalf("err = %v, want restart boom", err)
+	}
+}
+
 func TestMockManager_Snapshots(t *testing.T) {
 	m := NewMockManager()
 	ctx := context.Background()

--- a/internal/vm/quota_manager.go
+++ b/internal/vm/quota_manager.go
@@ -48,10 +48,13 @@ func (m *quotaManager) Update(ctx context.Context, id string, patch types.VMUpda
 	return m.base.Update(ctx, id, patch)
 }
 
-func (m *quotaManager) Start(ctx context.Context, id string) error { return m.base.Start(ctx, id) }
-func (m *quotaManager) Stop(ctx context.Context, id string) error { return m.base.Stop(ctx, id) }
-func (m *quotaManager) Delete(ctx context.Context, id string) error { return m.base.Delete(ctx, id) }
-func (m *quotaManager) Get(ctx context.Context, id string) (*types.VM, error) { return m.base.Get(ctx, id) }
+func (m *quotaManager) Start(ctx context.Context, id string) error   { return m.base.Start(ctx, id) }
+func (m *quotaManager) Stop(ctx context.Context, id string) error    { return m.base.Stop(ctx, id) }
+func (m *quotaManager) Restart(ctx context.Context, id string) error { return m.base.Restart(ctx, id) }
+func (m *quotaManager) Delete(ctx context.Context, id string) error  { return m.base.Delete(ctx, id) }
+func (m *quotaManager) Get(ctx context.Context, id string) (*types.VM, error) {
+	return m.base.Get(ctx, id)
+}
 func (m *quotaManager) List(ctx context.Context) ([]*types.VM, error) { return m.base.List(ctx) }
 func (m *quotaManager) CreateSnapshot(ctx context.Context, vmID string, name string) (*types.Snapshot, error) {
 	snap, err := m.base.CreateSnapshot(ctx, vmID, name)

--- a/tests/web/gui.spec.js
+++ b/tests/web/gui.spec.js
@@ -276,6 +276,19 @@ test.describe("VM Detail", () => {
     await expect(page.getByTestId("vm-detail-state")).toHaveText("running");
   });
 
+  test("restart running VM", async ({ page }) => {
+    await page.goto(BASE_URL);
+    await page.getByTestId("vm-row-web-server").click();
+
+    // Restart button is only shown while running.
+    await expect(page.getByTestId("btn-restart")).toBeVisible();
+    await page.getByTestId("btn-restart").click();
+
+    // After restart the VM should still be running.
+    await expect(page.getByTestId("vm-detail-state")).toHaveText("running");
+    await expect(page.getByTestId("btn-restart")).toBeVisible();
+  });
+
   test("create snapshot", async ({ page }) => {
     await page.goto(BASE_URL);
     await page.getByTestId("vm-row-web-server").click();

--- a/tests/web/mock-server.js
+++ b/tests/web/mock-server.js
@@ -163,6 +163,11 @@ const server = http.createServer(async (req, res) => {
     if (vm) { vm.state = "stopped"; return json(res, 200, { status: "stopped" }); }
     return json(res, 404, { error: "not found" });
   }
+  if ((m = p.match(/^\/api\/v1\/vms\/([^/]+)\/restart$/)) && method === "POST") {
+    const vm = vms.get(m[1]);
+    if (vm) { vm.state = "running"; return json(res, 200, { status: "restarted" }); }
+    return json(res, 404, { error: "not found" });
+  }
   if ((m = p.match(/^\/api\/v1\/vms\/([^/]+)\/clone$/)) && method === "POST") {
     const source = vms.get(m[1]);
     if (!source) return json(res, 404, { error: "not found" });

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -73,6 +73,7 @@ export const vms = {
     unwrap(apiClient.POST('/vms/{vmID}/clone', { params: { path: { vmID: id } }, body: { name } })),
   start: (id: string) => unwrap(apiClient.POST('/vms/{vmID}/start', { params: { path: { vmID: id } } })),
   stop: (id: string) => unwrap(apiClient.POST('/vms/{vmID}/stop', { params: { path: { vmID: id } } })),
+  restart: (id: string) => unwrap(apiClient.POST('/vms/{vmID}/restart', { params: { path: { vmID: id } } })),
   delete: (id: string) => unwrap(apiClient.DELETE('/vms/{vmID}', { params: { path: { vmID: id } } })),
   stats: (id: string, { since = '', fields = '' }: { since?: string; fields?: string } = {}) =>
     unwrap(apiClient.GET('/vms/{vmID}/stats', {

--- a/web/src/api/generated/schema.d.ts
+++ b/web/src/api/generated/schema.d.ts
@@ -346,6 +346,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/vms/{vmID}/restart": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Restart a VM (graceful stop then start; or just start if stopped) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    vmID: components["parameters"]["VMID"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description VM restarted */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["StatusResponse"];
+                    };
+                };
+                404: components["responses"]["APIError"];
+                default: components["responses"]["APIError"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/vms/{vmID}/clone": {
         parameters: {
             query?: never;
@@ -434,6 +474,57 @@ export interface paths {
                     };
                 };
                 400: components["responses"]["APIError"];
+                404: components["responses"]["APIError"];
+                503: components["responses"]["APIError"];
+                default: components["responses"]["APIError"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/vms/{vmID}/stats/stream": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Stream VM resource metrics (SSE)
+         * @description Server-Sent Events stream of `MetricSample` frames.  Each new sample
+         *     produced by the metrics collector is delivered as one `vm.stats`
+         *     event whose `data` field is a JSON-encoded `MetricSample` and whose
+         *     `id` is the sample's unix-nanosecond timestamp.  Clients should
+         *     seed history with `GET /vms/{vmID}/stats` before subscribing —
+         *     the stream provides no replay.  A `: keepalive` comment frame is
+         *     sent every 30 seconds.  The stream closes when the client
+         *     disconnects, the VM is deleted, or the daemon shuts down.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    vmID: components["parameters"]["VMID"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Server-Sent Events stream */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/event-stream": string;
+                    };
+                };
                 404: components["responses"]["APIError"];
                 503: components["responses"]["APIError"];
                 default: components["responses"]["APIError"];
@@ -1311,24 +1402,6 @@ export interface components {
             action: string;
             results: components["schemas"]["BulkVMActionResult"][];
         };
-        MetricSample: {
-            /** Format: date-time */
-            timestamp: string;
-            /** Format: double */
-            cpu_percent?: number | null;
-            /** Format: int64 */
-            mem_used_mb?: number | null;
-            /** Format: int64 */
-            mem_avail_mb?: number | null;
-            /** Format: int64 */
-            disk_read_bps?: number | null;
-            /** Format: int64 */
-            disk_write_bps?: number | null;
-            /** Format: int64 */
-            net_rx_bps?: number | null;
-            /** Format: int64 */
-            net_tx_bps?: number | null;
-        };
         TopVMItem: {
             vm_id: string;
             name: string;
@@ -1436,7 +1509,6 @@ export interface components {
              * @description Number of in-flight Server-Sent Event clients on
              *     `/api/v1/events/stream`.  Useful for spotting consumer pressure
              *     and stuck SSE connections.
-             *
              */
             event_stream_connections: number;
         };

--- a/web/src/pages/VMDetail.jsx
+++ b/web/src/pages/VMDetail.jsx
@@ -24,9 +24,10 @@ export default function VMDetail() {
   const [showCloneModal, setShowCloneModal] = useState(false);
   const [activeTab, setActiveTab] = useState('overview');
 
-  const startMut  = useMutation(vms.start);
-  const stopMut   = useMutation(vms.stop);
-  const deleteMut = useMutation(vms.delete);
+  const startMut   = useMutation(vms.start);
+  const stopMut    = useMutation(vms.stop);
+  const restartMut = useMutation(vms.restart);
+  const deleteMut  = useMutation(vms.delete);
 
   if (loading && !vm) return <div className="flex justify-center py-20"><Spinner size={20} /></div>;
   if (error) return <ErrorBanner message={error} />;
@@ -72,6 +73,11 @@ export default function VMDetail() {
           {vm.state === 'running' && (
             <button className="btn-secondary" onClick={() => { stopMut.execute(id).then(refresh); }} data-testid="btn-stop">
               <Square size={14} /> Stop
+            </button>
+          )}
+          {vm.state === 'running' && (
+            <button className="btn-secondary" onClick={() => { restartMut.execute(id).then(refresh); }} data-testid="btn-restart" title="Graceful stop and start">
+              <RotateCcw size={14} /> Restart
             </button>
           )}
           <button data-testid="btn-edit-vm" className="btn-secondary" onClick={() => setShowEditModal(true)} title="Edit resources">


### PR DESCRIPTION
## Summary

New, fully independent vertical slice. Adds a graceful **Restart** primitive at every layer of the lifecycle stack so operators can reboot a VM with one call instead of a stop+poll+start dance. Roadmap row **2.3.4** marked ✅ Done; the future scheduler `restart` action (5.2.5) now reuses the same manager method.

## What changed

### Manager
- `vm.Manager.Restart(ctx, id)` added to the interface.
- `LibvirtManager.Restart`: graceful `Domain.Shutdown()`, polls for SHUTOFF up to a 30s `restartShutdownTimeout`, then `Domain.Destroy()` fallback, then `Domain.Create()`. Already-stopped VMs just get started.
- `MockManager.Restart`: stateful mock with a `RestartErr` injection hook.
- `quotaManager.Restart`: passthrough (no resource delta to validate).

### REST
- `POST /api/v1/vms/{vmID}/restart` returns `{"status":"restarted"}`.
- Publishes `vm.restart_requested` (`app` source) on success.
- Wired into `internal/api/router.go` next to `/start` and `/stop`.

### CLI
- `vmsmith vm restart <id>` (single-id; no `--all` in v1 — bulk restart can land later).

### GUI
- "Restart" button on VMDetail beside Stop, only visible while the VM is running.
- New `vms.restart()` method in the typed API client.

### Tests
- **Unit**: `TestMockManager_Restart`, `TestMockManager_Restart_NotFound`, `TestMockManager_Restart_ErrorInjection`.
- **API integration**: `TestRestartVM`, `TestRestartVM_Error` in `internal/api/api_test.go`.
- **CLI**: `TestCLI_VMRestart`, `TestCLI_VMRestart_NotFound` in `internal/cli/commands_test.go`.
- **Mock GUI (Playwright)**: `restart running VM` in `tests/web/gui.spec.js`. Mock server learns the new endpoint.

### Docs / spec
- `docs/openapi.yaml`: new `/vms/{vmID}/restart` path; `web/src/api/generated/schema.d.ts` regenerated.
- `docs/ROADMAP.md`: new §2.3.4 (✅) describing the vertical slice; §5.2.5 schedule restart action now points at `vm.Manager.Restart`.
- `CLAUDE.md` REST quick reference includes the new endpoint.

### Drive-by
- Removed a duplicate `MetricSample` definition from `docs/openapi.yaml` that was blocking `npm run generate:api`.

## Test plan

- [x] `CGO_ENABLED=1 go vet -tags libvirt_dlopen ./...` — clean
- [x] `CGO_ENABLED=1 go test -tags libvirt_dlopen -race -count=1 -short ./...` — all packages green
- [x] `npm run generate:api` — clean
- [x] `npm run build` (web) — clean
- [ ] GitHub Actions to confirm (Playwright mock GUI runs in CI)

## Notes

- The Restart button is intentionally only shown while the VM is `running`. A stopped VM just shows Start — calling restart on a stopped VM still works at the API/CLI layer (it just starts), but exposing it in the GUI would be redundant with Start.
- v1 ships without a bulk variant. The existing `runBulkVMAction` helper assumes a single source state (running OR stopped), which doesn't fit restart cleanly. A future PR can add `vmsmith vm restart --all [--tag …]` once we've decided the semantics for already-stopped VMs in a bulk run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVA1QeSm8tWYaL9XcCzUwh)_