### PR TITLE
docs: add weekly digest for 2026-05-02

### DIFF
--- a/docs/weekly-digests/2026-05-02.md
+++ b/docs/weekly-digests/2026-05-02.md
@@ -1,0 +1,121 @@
+# Weekly Digest — 2026-05-02
+
+## Open Pull Requests (5)
+
+Sorted oldest first.
+
+| # | Title | Author | Age | Review Status | CI Status | Up to Date |
+|---|-------|--------|-----|---------------|-----------|------------|
+| [#167](https://github.com/chinmay28/VMSmith/pull/167) | docs(roadmap): mark clone and live-update coverage shipped | march26bot | 1 day | Approved | Passing | Conflicts |
+| [#168](https://github.com/chinmay28/VMSmith/pull/168) | feat(webhooks): event-bus webhook subsystem (4.2.15) | chinmay28 | 1 day | Commented (2 blockers noted) | Passing | Conflicts |
+| [#170](https://github.com/chinmay28/VMSmith/pull/170) | feat(metrics): live uPlot charts + SSE useVMStats hook (4.1.7) | chinmay28 | <1 day | Awaiting review | Passing | Conflicts |
+| [#171](https://github.com/chinmay28/VMSmith/pull/171) | feat(vm): add VM restart action across manager, REST, CLI, and GUI | chinmay28 | <1 day | Awaiting review | **Cancelled** | Behind main |
+| [#172](https://github.com/chinmay28/VMSmith/pull/172) | docs: sync roadmap status with shipped work | march26bot | <1 day | Awaiting review | No checks | Conflicts |
+
+### Flagged PRs
+
+- **PR #171 — cancelled CI:** Both "Backend build and tests (1.22)" and "Frontend build and mock GUI tests" checks were cancelled after timing out (~6 hours). CI needs to be re-triggered.
+- **PR #168 — review blockers identified:** Owner self-review flagged two should-fix-before-merge issues: (1) daemon ordering bug — `webhookMgr.Start()` runs after `daemon.started` is published, contradicting intended sequencing; (2) `validateTarget` DNS resolve does not pin the connection to the verified IPs, so the DNS-rebinding defense claim is overstated. Two additional nits: no jitter on backoff schedule, CLI variable shadowing.
+- **PR #167 — approved but has merge conflicts:** Docs-only change approved by chinmay28, but the branch has fallen behind main and needs a rebase before merging.
+- **PR #170, #172 — merge conflicts:** Both branches have diverged from main and need rebasing.
+
+No PRs have been open longer than 3 days.
+
+---
+
+## Commits Merged to `main` This Week (Apr 25 – May 2)
+
+**Total: 38 commits**
+
+| Date | Commit | Description |
+|------|--------|-------------|
+| May 2 | `80faf17` | docs(roadmap): sync live metrics and events status (#169) |
+| May 2 | `0099949` | docs(roadmap): mark event age retention complete (#165) |
+| May 1 | `3171b44` | docs(events): ARCHITECTURE.md "Event System" section (4.2.18) (#166) |
+| May 1 | `fd23a30` | feat(metrics): add VM stats SSE stream endpoint (4.1.5) (#164) |
+| May 1 | `5b5640c` | refactor(vm): publish lifecycle events to bus, persist via consumer (4.2.4) (#163) |
+| May 1 | `6219af9` | feat(events): surface active SSE connection count in host_stats (4.2.10) (#162) |
+| May 1 | `27d2912` | docs(roadmap): sync shipped metrics status (#157) |
+| May 1 | `040769a` | feat(events): emit system events for quota / DHCP / port-forward failures (4.2.7) (#155) |
+| May 1 | `7da3154` | feat(events): age-based retention pruning (4.2.8) (#159) |
+| May 1 | `a4c0d3b` | Add roadmap progress tracker (#160) |
+| May 1 | `9627eeb` | docs(roadmap): mark shipped metrics and events work (#150) |
+| May 1 | `16bd8dc` | docs(metrics): describe sampler architecture and scraping (#153) |
+| Apr 30 | `772bcaf` | feat(metrics): top-N VMs leaderboard API + CLI + dashboard widget (4.1.8) (#151) |
+| Apr 30 | `c77d5fe` | feat(web): VMDetail Metrics tab with REST polling (4.1.7 partial) (#152) |
+| Apr 30 | `a57ee97` | feat(events): `events follow` CLI + `useEventStream` hook (4.2.11 / 4.2.14) (#154) |
+| Apr 30 | `ddd7e7d` | feat(events): emit app+system events from handlers; add retention loop (#149) |
+| Apr 30 | `338bf96` | fix(api): reject uploads without a usable image name (#148) |
+| Apr 29 | `24f7217` | feat(events): Activity page, VMDetail Activity tab, vmsmith events list (#147) |
+| Apr 29 | `4b6dcea` | feat: add VM metrics collection and event bus infrastructure (#145) |
+| Apr 29 | `49e010f` | feat(web): generate frontend API types from OpenAPI (#146) |
+| Apr 29 | `891e1cc` | feat(api): serve Swagger UI docs (#143) |
+| Apr 29 | `aca9cdb` | fix(web): keep log viewer pinned where the user scrolled |
+| Apr 29 | `2387153` | docs: refine roadmap and align architecture for Phase 4/5 work |
+| Apr 28 | `e35195c` | feat: implement events API and timeline (#135) |
+| Apr 28 | `db72c2e` | docs(api): add initial OpenAPI schema (#137) |
+| Apr 28 | `796f941` | docs: refresh roadmap summary (#142) |
+| Apr 27 | `ffafbae` | fix(api): detect wrapped host-stats timeouts (#139) |
+| Apr 27 | `6051406` | test(web): cover VM clone modal flow (#126) |
+| Apr 27 | `ea753ef` | feat(install): auto-install runtime deps via OS detection (#138) |
+| Apr 27 | `4a7d571` | fix(vm): reserve NAT IPs for clones (#134) |
+| Apr 27 | `37b4108` | fix(test): isolate edit-modal test and wait for React commit |
+| Apr 27 | `ec7abd6` | fix(test): move VM edit polling test to React-app runner |
+| Apr 27 | `93eab23` | fix(web): keep VM edit modal inputs from resetting on poll refresh |
+| Apr 25 | `64fe62e` | test(e2e): cover API VM clone lifecycle (#128) |
+| Apr 25 | `a4ac331` | fix(vm): implement libvirt clone flow (#133) |
+| Apr 25 | `2fe0445` | fix(api): sanitize host stats errors (#129) |
+| Apr 25 | `4d03931` | test(web): cover real /vms rendering with malformed VM data (#131) |
+| Apr 25 | `9a70811` | docs: add weekly digest for 2026-04-25 (#130) |
+
+### Highlights
+
+- **Event System (Phase 4.2):** Massive progress — EventBus with fan-out/persistence, SSE streaming, Activity page + VM detail tab, CLI `events list` / `events follow`, system events for quota/DHCP/port-forward failures, age-based retention pruning, SSE connection count in host_stats, lifecycle event refactor through the bus, and full ARCHITECTURE.md documentation
+- **VM Resource Metrics (Phase 4.1):** Libvirt sampler with per-VM ring buffers, REST stats endpoint, Prometheus scrape handler, top-N leaderboard API + CLI + dashboard widget, VMDetail Metrics tab, and SSE stream endpoint for live stats
+- **OpenAPI & Swagger:** Initial OpenAPI schema, Swagger UI embedded in the daemon, and TypeScript type generation for the frontend
+- **VM Cloning:** Libvirt clone implementation, NAT IP reservations for clones, and E2E test coverage
+- **Roadmap Automation:** Progress tracker script + GitHub Action to auto-regenerate README progress block
+- **Install Improvements:** Auto-install runtime deps via OS detection in install.sh
+- **Bug Fixes:** Log viewer scroll pinning, edit modal input reset on poll, image upload name validation, host-stats timeout detection
+
+---
+
+## Roadmap Progress
+
+**97 / 138 items complete — 29.7% remaining**
+
+_Previous week (Apr 25): 71/105 complete (32.4% remaining) — 26 new items completed; roadmap expanded by 33 items as Phases 4.1, 4.2, 5.1, and 5.2 were broken into granular tasks_
+
+| Phase | Section | Done | Total | Status |
+|-------|---------|------|-------|--------|
+| 1.1 | CI/CD Pipeline | 5 | 6 | Branch protection (1.1.6) remaining |
+| 1.2 | Input Validation | 7 | 7 | Complete |
+| 1.3 | Test Coverage | 5 | 5 | Complete |
+| 2.1 | VM Cloning | 7 | 7 | Complete |
+| 2.2 | VM Tags & Metadata | 6 | 6 | Complete |
+| 2.3 | Bulk Operations | 3 | 3 | Complete |
+| 2.4 | VM Templates | 5 | 5 | Complete |
+| 3.1 | Auth & Authz | 4 | 5 | RBAC (3.1.5) is a future item |
+| 3.2 | TLS / HTTPS | 4 | 4 | Complete |
+| 3.3 | Systemd Integration | 4 | 4 | Complete |
+| 3.4 | Rate Limiting | 3 | 3 | Complete |
+| 3.5 | Resource Quotas | 3 | 3 | Complete |
+| 4.1 | VM Resource Metrics | 9 | 11 | Live charts (4.1.7) and E2E stress tests (4.1.10) in PR/remaining |
+| 4.2 | Event System | 15 | 18 | Webhooks (4.2.15) in PR; UI (4.2.16) and E2E (4.2.17) remaining |
+| 4.3 | OpenAPI / Swagger | 3 | 3 | Complete |
+| 5.1 | VNC Console | 0 | 12 | Not started |
+| 5.2 | Scheduled Operations | 1 | 13 | Only snapshot retention done |
+| 5.3 | VM Import/Export (OVA) | 0 | 3 | Not started |
+| 5.4 | Pagination & Filtering | 4 | 4 | Complete |
+| 5.5 | Multi-Host Management | 0 | 4 | Not started |
+| 6.1 | Developer Experience | 4 | 4 | Complete |
+| 6.2 | Packaging & Distribution | 4 | 4 | Complete |
+| 6.3 | Documentation | 3 | 4 | Video/GIF demos (6.3.4) remaining |
+
+### Next Up
+
+- **4.2.15** — Webhook subsystem (in PR #168, review blockers to resolve)
+- **4.1.7** — Live uPlot charts (in PR #170, awaiting review)
+- **2.3.4** — VM restart action (in PR #171, CI needs re-run)
+- **5.1.x** — VNC Console (Phase 5.1 — 12 tasks, not started)
+- **5.2.x** — Scheduled Operations (Phase 5.2 — 12 tasks remaining)


### PR DESCRIPTION
## Summary
- Add weekly digest covering May 2, 2026
- 5 open PRs reviewed (1 cancelled CI, 4 with merge conflicts)
- 38 commits merged to main this week
- Roadmap: 97/138 items complete (29.7% remaining)

## Test plan
- Docs-only change; no code modified

https://claude.ai/code/session_01XCTA1cvJaRHtxdv7VjCXTo

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCTA1cvJaRHtxdv7VjCXTo)_