### PR TITLE
test(events): cover bus slow-drop, persistence-error, and overflow paths

### DIFF
--- a/internal/events/bus_test.go
+++ b/internal/events/bus_test.go
@@ -229,6 +229,131 @@ func TestNewSystemEvent_NoAttrs(t *testing.T) {
 	}
 }
 
+// TestBusSlowSubscriberIsDropped guards the invariant that a subscriber whose
+// channel is full does not block the bus.  We fill the buffered subscriber
+// channel without ever reading from it, then publish more events than the
+// subscriber buffer can hold and confirm the bus continued processing — the
+// store reflects every persisted event even though the subscriber received
+// at most subscriberBufSize.
+func TestBusSlowSubscriberIsDropped(t *testing.T) {
+	store := &mockStore{}
+	bus := New(store)
+	bus.Start()
+	defer bus.Stop()
+
+	// Slow subscriber — never reads from ch.
+	_, cancel := bus.Subscribe("slow")
+	defer cancel()
+
+	// Fast subscriber — reads everything to confirm the bus still fans out
+	// to healthy subscribers while a slow one is being dropped.
+	fastCh, cancelFast := bus.Subscribe("fast")
+	defer cancelFast()
+
+	const total = subscriberBufSize + 32
+	for i := range total {
+		bus.Publish(&types.Event{Type: "tick", Message: fmt.Sprintf("%d", i)})
+	}
+
+	deadline := time.After(2 * time.Second)
+	for received := 0; received < total; {
+		select {
+		case <-fastCh:
+			received++
+		case <-deadline:
+			t.Fatalf("fast subscriber received %d/%d before timeout", received, total)
+		}
+	}
+
+	stored := store.all()
+	if len(stored) != total {
+		t.Fatalf("expected %d persisted events, got %d", total, len(stored))
+	}
+}
+
+// TestBusPersistenceErrorStillFansOut covers the branch in process() where
+// store.AppendEvent fails: the bus must still deliver to subscribers (with a
+// transient ID prefix) instead of silently dropping the event.
+func TestBusPersistenceErrorStillFansOut(t *testing.T) {
+	store := &mockStore{Err: fmt.Errorf("disk full")}
+	bus := New(store)
+	bus.Start()
+	defer bus.Stop()
+
+	ch, cancel := bus.Subscribe("test")
+	defer cancel()
+
+	bus.Publish(&types.Event{Type: "vm.started"})
+
+	select {
+	case evt := <-ch:
+		if evt.Type != "vm.started" {
+			t.Fatalf("type = %q, want vm.started", evt.Type)
+		}
+		if evt.ID == "" {
+			t.Error("ID should be assigned even when persistence fails")
+		}
+		// IDs from a failed persist are tagged so consumers can tell them apart.
+		if len(evt.ID) < len("transient-") || evt.ID[:len("transient-")] != "transient-" {
+			t.Errorf("ID = %q, want transient-* prefix on persistence failure", evt.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout — subscriber should still receive event when persistence fails")
+	}
+}
+
+// TestBusPublishOverflowDropsWithoutBlocking verifies that a flood larger than
+// the publish channel's buffer cannot deadlock Publish (which is invoked from
+// the libvirt event loop and must never block).  We use a store that blocks
+// AppendEvent until released, fill the publish buffer, then issue many more
+// Publish calls and assert each returns within a short timeout.
+func TestBusPublishOverflowDropsWithoutBlocking(t *testing.T) {
+	gate := make(chan struct{})
+	released := make(chan struct{})
+	store := &blockingStore{gate: gate, released: released}
+	bus := New(store)
+	bus.Start()
+	defer func() {
+		close(gate) // unblock the run goroutine before Stop drains.
+		bus.Stop()
+	}()
+
+	// First publish hits the run loop and blocks on AppendEvent (waiting on
+	// gate).  Subsequent publishes accumulate in publishCh until it's full.
+	for range publishBufSize + 16 {
+		done := make(chan struct{})
+		go func() {
+			bus.Publish(&types.Event{Type: "flood"})
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(200 * time.Millisecond):
+			t.Fatal("Publish blocked when buffer was full — must drop instead")
+		}
+	}
+}
+
+// blockingStore.AppendEvent waits on gate so the bus's run goroutine stalls
+// long enough for publishCh to fill.
+type blockingStore struct {
+	mu       sync.Mutex
+	gate     chan struct{}
+	released chan struct{}
+	seq      uint64
+	events   []*types.Event
+}
+
+func (b *blockingStore) AppendEvent(evt *types.Event) (uint64, error) {
+	<-b.gate
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.seq++
+	cp := *evt
+	b.events = append(b.events, &cp)
+	return b.seq, nil
+}
+
 func TestBusOccurredAtSet(t *testing.T) {
 	store := &mockStore{}
 	bus := New(store)


### PR DESCRIPTION
## Summary

Fills three unit-test gaps in `internal/events/bus.go` called out by the **4.2.17** task list (`EventBus` fan-out / slow-drop / ID monotonicity, etc.). ID monotonicity, fan-out, cancel, drain, and duplicate-name collision are already covered. The remaining slow-drop / persistence-error / publish-overflow paths are now covered too.

These three branches in `bus.go` are operationally important — the bus is invoked from the libvirt event loop, where blocking would freeze every domain lifecycle callback in the daemon. A regression here is silent and hard to debug.

## What changed

**`internal/events/bus_test.go`** — three new tests, no production code touched:

- **`TestBusSlowSubscriberIsDropped`** — a subscriber whose channel is full must be dropped, not block the bus. Asserts a fast subscriber still receives every event and the store persists the full set even while a slow subscriber is being dropped. Triggers `subscriberBufSize + 32` publishes and confirms the bus continued processing.
- **`TestBusPersistenceErrorStillFansOut`** — when `store.AppendEvent` returns an error, the bus must still deliver the event to live subscribers (with a `transient-*` ID prefix) instead of silently dropping it. Pins the contract documented in `process()`.
- **`TestBusPublishOverflowDropsWithoutBlocking`** — `Publish` must never block, regardless of pressure. Uses a `blockingStore` whose `AppendEvent` waits on a gate so the bus's run goroutine stalls; that fills `publishCh`; subsequent `Publish` calls must return within 200 ms (drop, not deadlock). Catches a regression where a future change accidentally makes the publish channel a blocking write.

## Test plan

- [x] `CGO_ENABLED=1 go test -tags libvirt_dlopen -count=1 -short -run "TestBusSlowSubscriberIsDropped|TestBusPersistenceErrorStillFansOut|TestBusPublishOverflowDropsWithoutBlocking" -v ./internal/events/...` — 3/3 pass
- [x] `CGO_ENABLED=1 go test -tags libvirt_dlopen -race -count=1 -short ./internal/events/...` — clean
- [x] `CGO_ENABLED=1 go vet -tags libvirt_dlopen ./internal/events/...` — clean
- [x] `gofmt -l internal/events/bus_test.go` — clean
- [ ] GitHub Actions to confirm

## Notes

- **No conflicts with any open chinmay28 PR.** Touches a single test file (`internal/events/bus_test.go`) that none of #178 / #179 / #181 / #185 / #192 / #194 / #198 modify.
- **4.2.17 is not fully ✅** — webhook integration retry/final-failure tests already exist in `internal/webhooks/manager_test.go` and SSE replay/heartbeat/410 already exist in `internal/api/handlers_events_stream_test.go`. The remaining gap on 4.2.17 is the **E2E** scenario ("start a real VM and assert `vm.started` arrives on the live SSE stream"), which depends on real libvirt + QEMU and belongs in `tests/e2e/`. This PR is a focused incremental piece, not the closing PR for the row.
- **Why not also touch `docs/ROADMAP.md`?** Three of the open PRs (#185, #192, #198) plus #195 already toggle roadmap rows / regen the README progress block; adding a fourth would force every other rebase to re-resolve the same conflict. Better to keep this test-only PR isolated and let whichever roadmap PR lands first claim the row text.

https://claude.ai/code/session_01XR77LPYprfmo9m6bZhC7sR

---
_Generated by [Claude Code](https://claude.ai/code/session_01XR77LPYprfmo9m6bZhC7sR)_