### PR TITLE
fix(api): surface the real libvirt error behind "vm definition failed"

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -797,7 +797,7 @@ File: `~/.vmsmith/config.yaml` or `/etc/vmsmith/config.yaml`
 daemon:
   listen: "0.0.0.0:8080"
   pid_file: "/var/run/vmsmith.pid"
-  log_file: "~/.vmsmith/vmsmith.log"   # structured log output; leave empty to disable file logging
+  log_file: "/var/log/vmsmith/vmsmith.log"   # structured log output (absolute path; '~' is NOT expanded). Leave empty to disable file logging.
 
 libvirt:
   uri: "qemu:///system"        # use qemu:///session for rootless

--- a/internal/api/handlers_vm.go
+++ b/internal/api/handlers_vm.go
@@ -156,7 +156,7 @@ func (s *Server) CreateVM(w http.ResponseWriter, r *http.Request) {
 
 	vm, err := s.vmManager.Create(r.Context(), spec)
 	if err != nil {
-		err = sanitizeManagerError(err)
+		err = logAndSanitizeManagerError("create vm", err)
 		writeAPIError(w, statusForAPIError(err, http.StatusInternalServerError), err)
 		return
 	}
@@ -238,7 +238,7 @@ func (s *Server) UpdateVM(w http.ResponseWriter, r *http.Request) {
 
 	vm, err := s.vmManager.Update(r.Context(), id, patch)
 	if err != nil {
-		err = sanitizeManagerError(err)
+		err = logAndSanitizeManagerError("update vm", err)
 		writeAPIError(w, statusForAPIError(err, http.StatusInternalServerError), err)
 		return
 	}
@@ -437,7 +437,7 @@ func (s *Server) CloneVM(w http.ResponseWriter, r *http.Request) {
 
 	cloned, err := s.vmManager.Clone(r.Context(), id, req.Name)
 	if err != nil {
-		err = sanitizeManagerError(err)
+		err = logAndSanitizeManagerError("clone vm", err)
 		writeAPIError(w, statusForAPIError(err, http.StatusInternalServerError), err)
 		return
 	}

--- a/internal/api/validation.go
+++ b/internal/api/validation.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/vmsmith/vmsmith/internal/logger"
 	validatepkg "github.com/vmsmith/vmsmith/internal/validate"
 	"github.com/vmsmith/vmsmith/pkg/types"
 )
@@ -301,6 +302,25 @@ func statusForAPIError(err error, fallback int) int {
 	default:
 		return fallback
 	}
+}
+
+// logAndSanitizeManagerError records the raw (unsanitized) manager error to the
+// structured log before stripping it down for the HTTP response. The
+// client-facing messages produced by sanitizeManagerError are intentionally
+// generic (e.g. "vm definition failed"), which leaves operators with no way to
+// diagnose the underlying libvirt/qemu failure. Logging the full error here —
+// keyed by the operation that produced it — preserves that detail in the ring
+// buffer and log file (surfaced via `vmsmith logs list` and the GUI Log Viewer)
+// while still returning the sanitized error to the caller. Already-typed API
+// errors carry their full message to the client, so they are not re-logged.
+func logAndSanitizeManagerError(op string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if !types.IsAPIError(err) {
+		logger.Error("api", "manager operation failed", "op", op, "error", err.Error())
+	}
+	return sanitizeManagerError(err)
 }
 
 func sanitizeManagerError(err error) error {

--- a/internal/api/validation_test.go
+++ b/internal/api/validation_test.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/vmsmith/vmsmith/internal/logger"
 	"github.com/vmsmith/vmsmith/pkg/types"
 )
 
@@ -311,6 +313,44 @@ func TestSanitizeManagerError(t *testing.T) {
 			err := sanitizeManagerError(tt.err)
 			assertAPIError(t, err, tt.wantCode, tt.wantMessage)
 		})
+	}
+}
+
+func TestLogAndSanitizeManagerError(t *testing.T) {
+	if err := logger.Init("", logger.LevelDebug); err != nil {
+		t.Fatalf("logger init: %v", err)
+	}
+
+	// A raw libvirt error is sanitized for the client but its full detail is
+	// preserved in the structured log so operators can diagnose the failure.
+	raw := errors.New("defining domain: internal error: process exited while connecting to monitor: qemu-kvm: unsupported machine type")
+	start := time.Now().Add(-time.Second)
+
+	got := logAndSanitizeManagerError("create vm", raw)
+	assertAPIError(t, got, "vm_definition_failed", "vm definition failed")
+
+	entries := logger.Get().Entries("error", start, 100)
+	var found bool
+	for _, e := range entries {
+		if e.Source == "api" && e.Fields["op"] == "create vm" && strings.Contains(e.Fields["error"], "unsupported machine type") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected raw error logged at error level with op=create vm; entries=%+v", entries)
+	}
+
+	// nil passes through without logging.
+	if err := logAndSanitizeManagerError("create vm", nil); err != nil {
+		t.Fatalf("expected nil for nil input, got %v", err)
+	}
+
+	// Already-typed API errors are returned verbatim (full message already
+	// reaches the client, so no re-logging is needed).
+	apiErr := types.NewAPIError("invalid_name", "vm name is required")
+	if got := logAndSanitizeManagerError("create vm", apiErr); got != apiErr {
+		t.Fatalf("expected typed API error returned unchanged, got %v", got)
 	}
 }
 

--- a/vmsmith.yaml.example
+++ b/vmsmith.yaml.example
@@ -4,7 +4,7 @@
 daemon:
   listen: "0.0.0.0:8080"
   pid_file: "/var/run/vmsmith.pid"
-  log_file: "~/.vmsmith/vmsmith.log"   # structured log output; leave empty to disable file logging
+  log_file: "/var/log/vmsmith/vmsmith.log"   # structured log output (absolute path; '~' is NOT expanded). Leave empty to disable file logging. For rootless/dev use, point this at a writable path under your home dir.
   tls:
     cert_file: ""                      # optional; when both cert_file + key_file are set, daemon serves HTTPS
     key_file: ""


### PR DESCRIPTION
## Problem

Creating a VM from an image via the GUI fails with the opaque message **"vm definition failed"**. That message comes from `sanitizeManagerError` (`internal/api/validation.go`) mapping any `"defining domain: …"` error from libvirt's `DomainDefineXML` (`internal/vm/lifecycle.go:219`) down to a generic client-facing string. The underlying libvirt detail (unsupported machine type, missing emulator binary, disk path/permission, AppArmor, etc.) was **discarded and never logged**, leaving operators with no way to diagnose the failure.

This is not a regression in domain-XML generation — `domain.go` / `lifecycle.go` haven't changed in the relevant area. The real cause lives in the host/libvirt environment and was simply invisible.

## Changes

**Observability (the fix)**
- Add `logAndSanitizeManagerError(op, err)`: logs the full, unsanitized manager error at `error` level (with `op` + `error` fields) **before** returning the sanitized error to the client. Already-typed API errors are returned verbatim and not re-logged (avoids noise on 404s, validation errors, etc.).
- Wire it into the VM **create**, **update**, and **clone** handler paths — the three operations that can emit `vm_definition_failed` / `redefining domain` failures.
- The detail now lands in the structured log (ring buffer + file), surfaced via `vmsmith logs list --level error` and the GUI **Log Viewer**.

**Daemon log file location**
- The daemon already writes a structured log file (`daemon.log_file`). The packaged/example config pointed it at `~/.vmsmith/vmsmith.log`, but config loading does **not** expand `~` — so the root system service would try to create a directory literally named `~`.
- Point the packaged/example config (and the ARCHITECTURE.md reference) at the absolute `/var/log/vmsmith/vmsmith.log` path that `docs/PRODUCTION_DEPLOYMENT.md` already recommends and the deb postinst already provisions. Added a no-tilde-expansion note inline. `DefaultConfig()` is unchanged (keeps `~/.vmsmith/vmsmith.log` for rootless/dev where `/var/log` isn't writable).

## Tests

- `TestLogAndSanitizeManagerError` verifies the raw error is logged at error level (with `op`) while the sanitized `vm_definition_failed` is returned, that `nil` passes through, and that typed API errors are returned unchanged.

⚠️ **Could not compile/run the test in this sandbox** — the `api` package transitively requires the cgo libvirt bindings and libvirt dev headers can't be installed here. `gofmt` is clean and the changes follow existing patterns; please run `make test-integration` in a libvirt-enabled environment before merging.

## How to get the real root cause now

Reproduce the failed create, then:
```
vmsmith logs list --level error --search "vm definition"
```
or filter by error level in the GUI Log Viewer — you'll now see `manager operation failed op=create vm error=defining domain: …` with the real libvirt message.

https://claude.ai/code/session_01Jca4UVvU83wtnXYKXggM53

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jca4UVvU83wtnXYKXggM53)_