### PR TITLE
fix(vm): reliably undefine domain on delete so VM names can be reused

### DIFF
--- a/internal/vm/lifecycle.go
+++ b/internal/vm/lifecycle.go
@@ -216,6 +216,20 @@ func (m *LibvirtManager) Create(ctx context.Context, spec types.VMSpec) (*types.
 		return nil, err
 	}
 
+	// Reap any orphaned libvirt domain that still carries this name. The API
+	// layer already rejects a create whose name still exists in the store, so a
+	// libvirt domain surviving here is never a live, tracked VM — it is leftover
+	// state from an earlier VM whose bbolt record was removed but whose libvirt
+	// definition was not fully torn down (e.g. an undefine that failed during
+	// Delete). Without this, recreating a previously-deleted VM name fails at
+	// DomainDefineXML with "domain already exists".
+	if orphan, lookupErr := m.conn.LookupDomainByName(spec.Name); lookupErr == nil {
+		logger.Warn("daemon", "reaping orphaned libvirt domain before recreate",
+			"vm", spec.Name)
+		_ = forceUndefineDomain(orphan)
+		orphan.Free()
+	}
+
 	dom, err := m.conn.DomainDefineXML(xmlDoc)
 	if err != nil {
 		return nil, fmt.Errorf("defining domain: %w", err)
@@ -633,12 +647,15 @@ func (m *LibvirtManager) Delete(ctx context.Context, id string) error {
 	dom, err := m.conn.LookupDomainByName(vm.Name)
 	if err == nil {
 		defer dom.Free()
-		// Try to destroy if running
-		state, _, _ := dom.GetState()
-		if state == libvirt.DOMAIN_RUNNING {
-			dom.Destroy()
+		if undefErr := forceUndefineDomain(dom); undefErr != nil {
+			// A leftover libvirt definition keeps the domain name registered.
+			// Because the domain is named after vm.Name (not the unique VM id),
+			// a future create that reuses this name would then fail at
+			// DomainDefineXML with "domain already exists". Surface it so the
+			// failure is diagnosable rather than silent.
+			logger.Warn("daemon", "failed to fully undefine domain on delete; recreating a VM with the same name may fail",
+				"vm", vm.Name, "error", undefErr.Error())
 		}
-		dom.UndefineFlags(libvirt.DOMAIN_UNDEFINE_SNAPSHOTS_METADATA)
 	}
 
 	// Remove any DHCP host reservation we may have added for this VM.
@@ -655,6 +672,32 @@ func (m *LibvirtManager) Delete(ctx context.Context, id string) error {
 	os.RemoveAll(vmDir)
 
 	return m.store.DeleteVM(id)
+}
+
+// forceUndefineDomain tears a libvirt domain down completely so its name is
+// released. It destroys the domain first when it is still active — a merely
+// undefined active domain becomes *transient* and keeps its name registered,
+// which would later collide with a create that reuses the name — then removes
+// the persistent definition together with any managed-save image, NVRAM, and
+// snapshot metadata that can otherwise block undefine. The combined-flags
+// UndefineFlags is attempted first and falls back to a plain Undefine on older
+// libvirt that rejects the flag set. Returns the final undefine error (nil on
+// success) so callers can detect a domain that survived teardown.
+func forceUndefineDomain(dom *libvirt.Domain) error {
+	if state, _, err := dom.GetState(); err == nil && state != libvirt.DOMAIN_SHUTOFF {
+		// Active (running/paused/...): destroy so the name is actually freed
+		// rather than demoted to a transient domain. Destroy also removes a
+		// transient domain outright, in which case the undefine below is a
+		// harmless no-op error we ignore via the fallback.
+		_ = dom.Destroy()
+	}
+	const flags = libvirt.DOMAIN_UNDEFINE_MANAGED_SAVE |
+		libvirt.DOMAIN_UNDEFINE_SNAPSHOTS_METADATA |
+		libvirt.DOMAIN_UNDEFINE_NVRAM
+	if err := dom.UndefineFlags(flags); err != nil {
+		return dom.Undefine()
+	}
+	return nil
 }
 
 // Update modifies the CPU count, RAM, or disk size of a VM.

--- a/tests/e2e/test_api_vm_lifecycle.py
+++ b/tests/e2e/test_api_vm_lifecycle.py
@@ -276,3 +276,48 @@ class TestAPIVMLifecycle:
 
         if image_id:
             api_delete(f"/images/{image_id}")
+
+
+@pytest.mark.api
+class TestAPIVMNameReuse:
+    """Regression: a VM name can be reused after the original is deleted.
+
+    Deleting a VM must fully undefine its libvirt domain (whose name is the VM
+    name, not the unique id). If teardown leaves the domain registered, the next
+    create that reuses the name fails at DomainDefineXML with "domain already
+    exists", surfacing to clients as the opaque "vm definition failed".
+    """
+
+    def test_recreate_with_same_name_after_delete(self, rocky_image, ssh_pubkey, api_vm_cleanup):
+        name = "e2e-api-name-reuse"
+        spec = {
+            "name": name,
+            "image": rocky_image,
+            "cpus": 2,
+            "ram_mb": 2048,
+            "disk_gb": 20,
+            "ssh_pub_key": ssh_pubkey,
+        }
+
+        # First create — wait until it is actually running so the domain is a
+        # live, defined libvirt domain that delete must tear down.
+        resp = api_post("/vms", json=spec)
+        assert resp.status_code == 201, f"First create failed: {resp.text}"
+        first_id = resp.json()["id"]
+        wait_for_vm_state(first_id, "running", timeout=120)
+
+        # Delete it (stop + DELETE). This must fully undefine the domain.
+        delete_vm_api(first_id)
+        deadline_resp = api_get(f"/vms/{first_id}")
+        assert deadline_resp.status_code == 404, "VM record should be gone after delete"
+
+        # Recreate with the SAME name. Before the fix this failed with
+        # 500 vm_definition_failed because the libvirt domain still existed.
+        resp = api_post("/vms", json=spec)
+        assert resp.status_code == 201, f"Recreate with reused name failed: {resp.text}"
+        second_id = resp.json()["id"]
+        api_vm_cleanup.append(second_id)
+
+        assert second_id != first_id, "Recreated VM should have a fresh unique id"
+        assert resp.json()["name"] == name
+        wait_for_vm_state(second_id, "running", timeout=120)


### PR DESCRIPTION
## Problem

Creating a VM from an image fails with **"vm definition failed"** when the chosen name was previously used by a VM that was created and then deleted — using a fresh name works. (Follow-up to #319, which made the underlying libvirt error visible; this PR fixes the root cause it exposes.)

The libvirt domain is named after the VM's **`Name`**, not its unique `vm-<unix-nano>` id. So the name must be released on delete, or the next create that reuses it fails at `DomainDefineXML` with *"domain already exists"* — which `sanitizeManagerError` maps to the opaque `vm_definition_failed`.

`Delete` was not reliably tearing the domain down:

```go
state, _, _ := dom.GetState()
if state == libvirt.DOMAIN_RUNNING {   // misses PAUSED / suspended
    dom.Destroy()
}
dom.UndefineFlags(libvirt.DOMAIN_UNDEFINE_SNAPSHOTS_METADATA) // error ignored
```

- A **paused/suspended** domain (state `PAUSED`, not `RUNNING`) was never destroyed; undefining an *active* domain only demotes it to a **transient** domain that keeps its name registered.
- Domains with a **managed-save image** or **NVRAM** reject undefine without the matching flags, so the call failed silently.
- Every error was ignored, while `store.DeleteVM` still removed the bbolt record — leaving libvirt holding the name with nothing tracking it.

## Fix

- **`forceUndefineDomain(dom)`** — destroys the domain when it is in any active state (so the name is truly freed, not demoted to transient), then undefines with `MANAGED_SAVE | SNAPSHOTS_METADATA | NVRAM`, falling back to a plain `Undefine` on older libvirt. Returns the final error so callers can tell when teardown didn't take.
- **`Delete`** now uses it and logs a warning (via the logging added in #319) if teardown fails, so a lingering name is diagnosable instead of silent.
- **`Create`** reaps an orphaned libvirt domain carrying the same name *before* `DomainDefineXML`. The API layer + store already reject a create whose name still exists in the store, so any libvirt domain surviving here is provably an untracked orphan — this self-heals VMs already orphaned by the old behavior, not just newly-deleted ones.

## Tests

- E2E regression test `TestAPIVMNameReuse.test_recreate_with_same_name_after_delete`: create → wait running → delete → recreate with the **same name** → expect 201 + a fresh id.

⚠️ **Could not compile or run tests in this sandbox** — the `vm`/`api` packages require the cgo libvirt bindings and libvirt dev headers can't be installed here. I verified the undefine constants/methods exist in the pinned `libvirt.org/go/libvirt@v1.10000.0` binding and `gofmt` is clean, but please run `make test` and the E2E suite in a libvirt-enabled environment before merging.

https://claude.ai/code/session_01Jca4UVvU83wtnXYKXggM53

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jca4UVvU83wtnXYKXggM53)_